### PR TITLE
feat(claude): add merged branch cleanup to /main skill

### DIFF
--- a/claude/.claude/skills/main/SKILL.md
+++ b/claude/.claude/skills/main/SKILL.md
@@ -12,10 +12,12 @@ Use this skill when the user wants to switch to the main branch and sync it with
 
 1. Run `git checkout main`
 2. Run `git pull origin main`
-3. Report the result — current branch and the pull output (fast-forward, already up to date, etc.)
+3. Delete merged local branches: `git branch --merged main | grep -v '^\*\|main\|master' | xargs -r git branch -d`
+4. Report the result — current branch, the pull output (fast-forward, already up to date, etc.), and any branches that were deleted
 
 ## Rules
 
 - If there are uncommitted changes on the current branch, warn the user before switching and ask whether to stash, commit, or abort
 - If `main` does not exist but `master` does, use `master` instead
 - Always report the final state: current branch and whether the pull brought in new commits
+- If no merged branches were found to delete, omit that from the report (don't mention it)


### PR DESCRIPTION
## Summary
- Adds automatic merged branch deletion to the `/main` skill after pulling main

## Motivation
After switching to main and pulling, stale local branches that have already been merged accumulate over time. Adding cleanup here keeps the branch list tidy without requiring a separate manual step.

## Changes
- Added step 3: delete merged local branches via `git branch --merged main | grep -v '^\*\|main\|master' | xargs -r git branch -d`
- Updated step 4 (formerly 3) to include deleted branches in the report
- Added rule: omit the cleanup from the report if no branches were deleted

## Test Plan
- [ ] Run `/main` after merging a feature branch — confirm the merged branch is deleted and reported
- [ ] Run `/main` with no merged branches — confirm the cleanup step is silent