### PR TITLE
feat(claude): workflow audit fixes — triggers, gherkin lint, stow, discoverability

### DIFF
--- a/claude/.claude/.stow-local-ignore
+++ b/claude/.claude/.stow-local-ignore
@@ -1,0 +1,4 @@
+# Exclude Claude Code's runtime project-state directory.
+# When Claude works inside ~/.claude/ it creates a nested .claude/ for
+# session/task/memory data — runtime state, not dotfiles config.
+^\.claude$

--- a/claude/.claude/commands/audit.md
+++ b/claude/.claude/commands/audit.md
@@ -1,0 +1,21 @@
+# Workflow Audit
+
+Reads every file under `.claude/` — agents, hooks, skills, commands, rules, and `settings.json` — and reports what's suboptimal with specific fixes, grouped by category and ordered by impact.
+
+## What it checks
+
+- **Correctness** — rules or skills that fire in the wrong context, semantic mismatches, contradictory steps
+- **Redundancy** — duplicate sources of truth, skills that duplicate agent logic, rules covered elsewhere
+- **Missing Connections** — skills without agent delegation, agents without skill entry points, rules with no hook enforcement
+- **Coverage Gaps** — inconsistent language coverage, hooks that miss file types in the same family
+- **Discoverability** — workflows not surfaced via commands, skills or agents that solve the same problem without knowing about each other
+
+## Usage
+
+```
+/audit
+```
+
+Run periodically after adding new skills, agents, rules, or hooks to catch integration gaps before they accumulate.
+
+After reporting findings, the audit will ask which to implement before making any changes.

--- a/claude/.claude/commands/workflow.md
+++ b/claude/.claude/commands/workflow.md
@@ -41,6 +41,8 @@ Checkout main, pull latest, delete merged branches.
 | Deprecated API calls | `/migrate` | Suggested by `migrate-suggest` rule when old patterns detected |
 | Structural design issues | `/refactor` | Go, Python, and Neovim supported |
 | Missing documentation | `/go-docs` / `/py-docs` / `/nvim-docs` / `/gherkin-docs` | Suggested by `docs-suggest` rule when public API added without docs |
+| Post-review code quality | `/simplify` | After `/review` to apply fixes for reuse, quality, and efficiency |
+| Go performance analysis | `/go-bench` | When benchmarking Go code or investigating allocations and throughput |
 
 ---
 
@@ -50,6 +52,24 @@ Checkout main, pull latest, delete merged branches.
 |---|---|
 | Test failure or bug | `/debug` — triage then escalates to language specialist |
 | Need deep root cause | Invoke `go-debugger`, `py-debugger`, `nvim-debugger`, or `gherkin-debugger` directly |
+
+---
+
+## Running Tests
+
+Use `/test-runner` to run the test suite and get a structured failure report without flooding the conversation with verbose output. Detects pytest, jest, vitest, and make automatically.
+
+```
+/test-runner          # run tests in the current project
+```
+
+Or run directly when you need the raw output:
+
+| Language | Command |
+|---|---|
+| Go | `go test -race ./...` |
+| Python | `pytest` |
+| Neovim/Lua | `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/"` |
 
 ---
 

--- a/claude/.claude/hooks/lint.sh
+++ b/claude/.claude/hooks/lint.sh
@@ -31,6 +31,10 @@ case "${FILE##*.}" in
       luacheck --quiet "$FILE"
     fi
     ;;
+  feature)
+    command -v gherkin-lint &>/dev/null || exit 0
+    gherkin-lint "$FILE"
+    ;;
   *)
     exit 0
     ;;

--- a/claude/.claude/hooks/protect-main.sh
+++ b/claude/.claude/hooks/protect-main.sh
@@ -8,18 +8,27 @@ set -uo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
-# Only check git commit commands
-[[ "$COMMAND" != *"git commit"* ]] && exit 0
+# Check for direct commits to main/master
+if [[ "$COMMAND" == *"git commit"* ]]; then
+  BRANCH=$(cd "${CLAUDE_PROJECT_DIR:-.}" && git branch --show-current 2>/dev/null)
+  if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+    echo "ERROR: Direct commit to '$BRANCH' is not allowed."
+    echo ""
+    echo "  Create a feature branch first, or use /ship which handles branching automatically."
+    echo "    git checkout -b feature/<name>"
+    exit 1
+  fi
+fi
 
-# Get current branch
-BRANCH=$(cd "${CLAUDE_PROJECT_DIR:-.}" && git branch --show-current 2>/dev/null)
-
-if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
-  echo "ERROR: Direct commit to '$BRANCH' is not allowed."
-  echo ""
-  echo "  Create a feature branch first, or use /ship which handles branching automatically."
-  echo "    git checkout -b feature/<name>"
-  exit 1
+# Check for force-push to main/master
+if [[ "$COMMAND" == *"git push"* ]] && ([[ "$COMMAND" == *"--force"* ]] || [[ "$COMMAND" == *" -f "* ]] || [[ "$COMMAND" == *" -f" ]]); then
+  if [[ "$COMMAND" == *"main"* || "$COMMAND" == *"master"* ]]; then
+    echo "ERROR: Force-push to a protected branch is not allowed."
+    echo ""
+    echo "  Force-pushing to main/master can overwrite history and break other contributors."
+    echo "  If you need to update the remote, use: git push --force-with-lease"
+    exit 1
+  fi
 fi
 
 exit 0

--- a/claude/.claude/rules/docs-suggest.md
+++ b/claude/.claude/rules/docs-suggest.md
@@ -3,6 +3,7 @@ paths:
   - "**/*.go"
   - "**/*.py"
   - "**/*.lua"
+  - "**/*.feature"
 ---
 
 # Suggest Documentation When Public API Changes
@@ -14,6 +15,7 @@ When you add or modify an exported/public symbol — function, type, class, or m
 | Go | suggest `/go-docs` | Exported symbol (`PascalCase`) added or changed without a preceding `//` comment |
 | Python | suggest `/py-docs` | Public function or class (no `_` prefix) added or changed without a docstring |
 | Neovim/Lua | suggest `/nvim-docs` | Public module function in `lua/*/init.lua` added or changed without a comment block |
+| Gherkin | suggest `/gherkin-docs` | A new `.feature` file is added to the suite |
 
 **Keep the suggestion to one line:**
 > Consider running `/go-docs` to document the new exported symbols.

--- a/claude/.claude/rules/tdd.md
+++ b/claude/.claude/rules/tdd.md
@@ -3,19 +3,8 @@ description: Enforces test-driven development for all code changes
 paths:
   - "**/*.py"
   - "**/*.go"
-  - "**/*.ts"
-  - "**/*.tsx"
-  - "**/*.js"
-  - "**/*.jsx"
   - "**/*.lua"
-  - "**/*.rb"
-  - "**/*.rs"
-  - "**/*.java"
-  - "**/*.kt"
-  - "**/*.swift"
-  - "**/*.c"
-  - "**/*.cpp"
-  - "**/*.cs"
+  - "**/*.feature"
 ---
 
 # Test-Driven Development — Mandatory

--- a/claude/.claude/skills/audit/SKILL.md
+++ b/claude/.claude/skills/audit/SKILL.md
@@ -10,18 +10,24 @@ triggers:
 
 ### 1. Read Everything
 
-Read every file under `.claude/`:
+**Use two parallel batches — do not read files sequentially.**
 
-```
-agents/       — all *.md agent definitions
-hooks/        — all *.sh hook scripts
-skills/       — all */SKILL.md skill files
-commands/     — all *.md command files
-rules/        — all *.md rule files
-settings.json — permissions, hooks, plugins
-```
+**Batch 1 — discover file paths** (run these Glob calls in a single parallel message):
+- `Glob("agents/*.md")`
+- `Glob("hooks/*.sh")`
+- `Glob("skills/*/SKILL.md")`
+- `Glob("commands/*.md")`
+- `Glob("rules/*.md")`
 
-Do not skip any file. The audit is only as good as the coverage.
+**Batch 2 — read all discovered files plus settings** (issue every Read call in a single parallel message):
+- `skills/*/SKILL.md` — read with `limit: 50` (frontmatter + purpose section is sufficient; full workflow steps are not needed for structural analysis)
+- `agents/*.md` — read in full (they're short and the full content is needed)
+- `hooks/*.sh` — read in full (enforcement logic must be understood completely)
+- `rules/*.md` — read in full (they're short and the full path/content is needed)
+- `commands/*.md` — read in full
+- `settings.json` and `CLAUDE.md` — read in full
+
+Do not read files one at a time. Issue all Read calls together so they execute concurrently. If a skill's first 50 lines reveal an issue that requires deeper inspection, read that specific file in full as a follow-up. The audit is only as good as its coverage — do not skip any file.
 
 ### 2. Analyze Against Five Categories
 

--- a/claude/.claude/skills/gherkin-feature/SKILL.md
+++ b/claude/.claude/skills/gherkin-feature/SKILL.md
@@ -1,5 +1,7 @@
 ---
 description: Guides writing new Gherkin feature files and step definitions following BDD best practices.
+triggers:
+  - /gherkin-feature
 paths:
   - "**/*.feature"
 ---

--- a/claude/.claude/skills/go-feature/SKILL.md
+++ b/claude/.claude/skills/go-feature/SKILL.md
@@ -1,5 +1,7 @@
 ---
 description: Guides development of new Go features following clean architecture and idiomatic Go patterns.
+triggers:
+  - /go-feature
 paths:
   - "**/*.go"
 ---

--- a/claude/.claude/skills/nvim-docs/SKILL.md
+++ b/claude/.claude/skills/nvim-docs/SKILL.md
@@ -1,5 +1,7 @@
 ---
 description: Generates Neovim plugin documentation in vimdoc format.
+triggers:
+  - /nvim-docs
 paths:
   - "**/*.lua"
 ---

--- a/claude/.claude/skills/nvim-feature/SKILL.md
+++ b/claude/.claude/skills/nvim-feature/SKILL.md
@@ -1,5 +1,7 @@
 ---
 description: Guides development of new Neovim plugin features using idiomatic Lua and the Neovim API.
+triggers:
+  - /nvim-feature
 paths:
   - "**/*.lua"
 ---

--- a/claude/.claude/skills/py-feature/SKILL.md
+++ b/claude/.claude/skills/py-feature/SKILL.md
@@ -1,5 +1,7 @@
 ---
 description: Guides development of new Python features following hexagonal architecture and clean code principles.
+triggers:
+  - /py-feature
 paths:
   - "**/*.py"
 ---

--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -1,3 +1,13 @@
+# ────────[ Functions ]────────
+twc() { cd ~/src/github/TheWeatherCompany; }
+test() { cd ~/src/github/TheWeatherCompany/qa/testing; }
+core() { cd ~/src/github/TheWeatherCompany/qa/core; }
+tools() { cd ~/src/github/TheWeatherCompany/qa/core/sun-qa-python-tools; }
+market() { cd ~/src/github/TheWeatherCompany/sun-claude-marketplace; }
+ocrosby()  { cd ~src/github/ocrosby; }
+yodad() { cd ~/src/github/jedi-knights/yoda.nvim; }
+snvimd() { cd ~/src/github/TheWeatherCompany/sun-neovim; }
+
 # ────────[ Aliases ]────────
 alias ll="ls -la"
 alias gti="git"
@@ -7,6 +17,7 @@ for variant in personal yoda kickstart astro chad lunar lazy; do
   alias "nvim-${variant}"="NVIM_APPNAME=\"nvim-${variant}\" nvim"
 done
 alias yoda='NVIM_APPNAME="nvim-yoda" nvim'
+alias snvim='NVIM_APPNAME="sun-neovim" nvim'
 
 # ────────[ Environment Variables ]────────
 export GOPATH="$HOME/go"


### PR DESCRIPTION
## Summary
- Add `triggers` frontmatter to all four `*-feature` skills and `nvim-docs` so they're invocable as slash commands
- Add Gherkin linting to the post-edit lint hook, bringing `.feature` files to parity with Go/Python/Lua
- Add `/simplify` and `/go-bench` to `workflow.md` Maintenance table so they're discoverable
- Extend `protect-main.sh` to block force-push to main/master (not just direct commits)
- Fix `tdd.md` rule paths to match only supported languages (remove ts/js/rb/rs/etc.)
- Fix `docs-suggest.md` to include `.feature` files and the Gherkin row
- Improve `audit/SKILL.md` with parallel read instructions for faster execution
- Add `commands/audit.md` command file for `/audit` discoverability
- Add `.stow-local-ignore` to prevent Claude Code's runtime `.claude/` project-state from being picked up by stow
- Add shell navigation functions and `snvim` alias to `.zshrc`

## Motivation
A `/audit` run identified five categories of gaps in the Claude workflow system. The four `*-feature` skills were undiscoverable via slash commands despite being the primary Step 2 in the standard workflow. Gherkin was the only language without post-edit lint feedback. Two useful system skills (`/simplify`, `/go-bench`) were invisible to users reading `workflow.md`. The `protect-main` hook only blocked commits, not force-pushes. The `tdd` rule was firing on language paths (TypeScript, Ruby, Rust, etc.) that have no supporting agents or skills.

A separate stow issue caused all three hooks to be unreachable at runtime — `~/.claude/hooks/` was never created after the hooks were added to dotfiles, triggering hook errors on every Bash tool call.

## Changes
- `skills/*/SKILL.md` — added `triggers` to `go-feature`, `py-feature`, `nvim-feature`, `gherkin-feature`, `nvim-docs`
- `hooks/lint.sh` — added `feature` case with `gherkin-lint` guard
- `hooks/protect-main.sh` — added force-push detection for main/master
- `commands/workflow.md` — added `/simplify` and `/go-bench` rows to Maintenance table; added Running Tests section
- `commands/audit.md` — new command file surfacing `/audit` in autocomplete
- `rules/tdd.md` — narrowed paths to `**/*.py`, `**/*.go`, `**/*.lua`, `**/*.feature`
- `rules/docs-suggest.md` — added `**/*.feature` to paths and Gherkin row to trigger table
- `skills/audit/SKILL.md` — replaced sequential read instructions with parallel batch strategy
- `.claude/.stow-local-ignore` — excludes the nested `.claude/` runtime state dir from stow management
- `shell/.zshrc` — added `twc`, `test`, `core`, `tools`, `market`, `ocrosby`, `yodad`, `snvimd` navigation functions and `snvim` alias

## Test Plan
- [ ] Type `/go-feature` in a Go project — confirm it appears in autocomplete and loads the skill
- [ ] Type `/py-feature`, `/nvim-feature`, `/gherkin-feature` — confirm same
- [ ] Edit a `.feature` file — confirm lint hook fires if `gherkin-lint` is installed, silently skips if not
- [ ] Attempt `git push --force origin main` — confirm `protect-main.sh` blocks it
- [ ] Run `stow -R claude` from `~/dotfiles` — confirm it completes without conflicts
- [ ] Confirm `~/.claude/hooks` is a symlink: `ls -la ~/.claude/hooks`
- [ ] Confirm no hook errors appear on normal Bash commands in a new Claude session