### PR TITLE
chore(claude): enforce TDD red-green-refactor in Go agents and feature skill

### DIFF
--- a/claude/.claude/agents/go-debugger.md
+++ b/claude/.claude/agents/go-debugger.md
@@ -48,11 +48,34 @@ You are a Go debugging specialist focused on root cause analysis.
 - Check every assumption: is the pointer nil? Is the channel closed? Is the context cancelled?
 - For concurrent code: map out goroutine ownership and channel flow
 
+## Fix workflow — TDD required
+
+**Do not touch production code until a failing test exists.** This is mandatory, not optional.
+
+### RED — Write a failing test
+
+1. Write a test in the corresponding `_test.go` file that reproduces the bug
+2. Run `go test ./...` (or the relevant package) and **show the failure output**
+3. Confirm the test fails for the right reason — the bug, not a syntax error or import issue
+4. Do not edit any production file until this step is complete
+
+### GREEN — Fix the bug
+
+1. Make the minimal code change that causes the failing test to pass
+2. Run `go test ./...` and **show the passing output**
+3. Confirm all previously passing tests still pass
+
+### REFACTOR — Clean up if needed
+
+1. If the fix introduced duplication or unclear code, clean it up now
+2. Run all tests after every change to confirm nothing broke
+
 ## Output format
 
 For every bug, report:
 
 1. **Root cause** — the specific line and condition that triggers the failure
 2. **Evidence** — code references and state that confirm the diagnosis
-3. **Fix** — minimal code change that resolves the issue
-4. **Regression risk** — what else could break and how to verify
+3. **Failing test** — the test written to reproduce the bug, with run output showing it fail
+4. **Fix** — minimal code change that makes the test pass, with run output showing it pass
+5. **Regression risk** — what else could break and how to verify

--- a/claude/.claude/agents/go-reviewer.md
+++ b/claude/.claude/agents/go-reviewer.md
@@ -51,14 +51,18 @@ You are a senior Go code reviewer. Your reviews are thorough but focused — fla
 - [ ] Short variable names for short scopes, descriptive for wider scopes
 - [ ] `any` used instead of `interface{}`
 
-### Testing
+### Testing and TDD compliance
 
+- [ ] Tests exist for every changed behavior — untested changes are a Critical finding
+- [ ] Tests were written alongside (or before) the implementation, not retrofitted — look for test files with commit dates matching production files
 - [ ] Table-driven tests with `t.Run` for data variations
 - [ ] `t.Helper()` called in all test helper functions
 - [ ] `t.Cleanup()` for teardown, `t.TempDir()` for temp directories
 - [ ] Fakes implementing port interfaces, not mocking libraries
 - [ ] Race detector passing: `go test -race`
 - [ ] Performance-sensitive code has corresponding `Benchmark*` functions — flag absence as a Suggestion if the code is on a hot path, processes large inputs, involves tight loops, or is explicitly called out as latency-sensitive
+
+**When suggesting fixes:** Apply the TDD fix workflow — propose a failing test first, then the minimal production code change. Do not propose production code changes without a corresponding test change.
 
 ### Performance and resource management
 

--- a/claude/.claude/skills/go-feature/SKILL.md
+++ b/claude/.claude/skills/go-feature/SKILL.md
@@ -24,12 +24,34 @@ paths:
 
 > For features that introduce new packages, significant abstractions, or cross-cutting concerns, invoke `/architect` before implementing to get a comprehensive structural proposal.
 
-### 3. Implement (Domain First)
+### 3. Implement (TDD — Domain First)
 
-- Start with domain types and service methods — pure logic, no I/O
-- Define port interfaces for any new external dependencies
-- Implement adapters: HTTP handlers, DB repositories, API clients
-- Wire dependencies in `cmd/` via constructor injection
+Follow the red-green-refactor cycle for every behavior. **No production code without a failing test first.**
+
+#### RED — Write the failing test
+
+1. Write a test in the corresponding `_test.go` file for the first behavior
+2. Run `go test ./...` and show the failure output to the user
+3. Confirm it fails for the right reason — not a syntax error or missing type
+
+#### GREEN — Make it pass
+
+1. Write only the production code needed to make the failing test pass
+2. Run `go test ./...` and show the passing output to the user
+3. Confirm all existing tests still pass
+
+#### REFACTOR — Clean up
+
+1. Remove duplication, improve naming, apply patterns — while all tests stay green
+2. Run `go test ./...` after each change
+
+#### Repeat for each behavior
+
+- Domain types and service methods first — pure logic, no I/O
+- Then port interfaces for any new external dependencies
+- Then adapters: HTTP handlers, DB repositories, API clients
+- Then wire dependencies in `cmd/` via constructor injection
+- Each new behavior gets its own red-green-refactor cycle
 
 ### 4. Structure
 


### PR DESCRIPTION
## Summary
- `go-debugger` now requires a failing test before any production code change
- `go-reviewer` flags untested changes as Critical and proposes fixes test-first
- `go-feature` step 3 explicitly walks through RED-GREEN-REFACTOR per behavior

## Motivation
Go agents were implementing and reviewing code without enforcing the TDD cycle. The `tdd.md` rule has `paths: ["**/*.go"]` but agents don't inherit rules automatically — each agent/skill only acts on its own definition. TDD guidance had to be embedded directly into each file.

## Changes
- `agents/go-debugger.md`: Added mandatory RED-GREEN-REFACTOR fix workflow section; updated output format to require fail/pass run output
- `agents/go-reviewer.md`: Expanded Testing section to include TDD compliance checks; added instruction to propose fixes test-first
- `skills/go-feature/SKILL.md`: Replaced flat "Implement" step with explicit red-green-refactor cycle with per-behavior repetition

## Test Plan
- [ ] Use `go-debugger` on a bug — confirm it writes a failing test before proposing a fix
- [ ] Use `go-reviewer` on untested code — confirm it flags missing tests as Critical
- [ ] Use `/go-feature` — confirm it runs tests at each RED and GREEN step