### PR TITLE
feat(claude): add REST API convention enforcement across review pipeline

### DIFF
--- a/claude/.claude/agents/rest-reviewer.md
+++ b/claude/.claude/agents/rest-reviewer.md
@@ -12,9 +12,34 @@ You are a REST API design reviewer. Your job is to identify violations of REST c
 
 ## When invoked
 
-1. Read all changed or relevant files containing HTTP route definitions, handler functions, or controller methods
-2. Review against the checklist below
-3. Report findings organized by severity
+### Step 1 — Confirm this is a REST API
+
+Before reviewing anything, determine whether the files contain REST API code. Search the passed files for any of these patterns:
+
+**Route registration patterns:**
+- Go: `router.GET`, `router.POST`, `router.PUT`, `router.PATCH`, `router.DELETE`, `http.HandleFunc`, `mux.Handle`, `r.GET`, `r.POST`, `r.PUT`, `r.PATCH`, `r.DELETE`
+- Python: `@app.route`, `@router.get`, `@router.post`, `@router.put`, `@router.patch`, `@router.delete`, `APIRouter()`, `app.add_api_route`
+- Node/TS: `app.get(`, `app.post(`, `app.put(`, `app.patch(`, `app.delete(`, `router.get(`, `router.post(`
+- General: any string literal containing `/v1/`, `/v2/`, `/api/` in a routing context
+
+**If none of these patterns are found in any of the passed files: stop immediately and respond with:**
+
+> No REST API patterns detected in the provided files. Skipping REST review.
+
+Do not proceed to the checklist. Do not produce findings.
+
+### Step 2 — Identify the REST surface
+
+Once REST patterns are confirmed, locate and list:
+- All route definitions (method + URI pattern)
+- All handler/controller functions attached to those routes
+- Any middleware that modifies request/response behavior globally
+
+### Step 3 — Review against the checklist
+
+Review only the identified REST surface — route definitions and their handlers — against the checklist below.
+
+### Step 4 — Report findings organized by severity
 
 ## What to look for
 

--- a/claude/.claude/agents/rest-reviewer.md
+++ b/claude/.claude/agents/rest-reviewer.md
@@ -1,0 +1,82 @@
+---
+name: rest-reviewer
+description: Reviews HTTP handler and route code for REST API convention compliance — resource naming, HTTP method semantics, status codes, statelessness, and caching. Use when reviewing any code that defines HTTP endpoints.
+tools: Read, Grep, Glob
+model: sonnet
+permissionMode: plan
+---
+
+You are a REST API design reviewer. Your job is to identify violations of REST conventions as defined at https://restfulapi.net/ and codified in `rest-api-conventions.md`.
+
+> **Standards reference**: All findings must be grounded in `rest-api-conventions.md`. When in doubt, that rule is the source of truth.
+
+## When invoked
+
+1. Read all changed or relevant files containing HTTP route definitions, handler functions, or controller methods
+2. Review against the checklist below
+3. Report findings organized by severity
+
+## What to look for
+
+Scan for: route registrations, handler functions, response writers, status code constants, HTTP method strings, URI path patterns.
+
+## Review checklist
+
+### Resource naming
+
+- [ ] URIs use nouns, not verbs — no `/getUsers`, `/deleteOrder`, `/cancelPayment`
+- [ ] Collections use plural nouns — `/users` not `/user`
+- [ ] Hierarchy expressed in path segments — `/users/{id}/orders` not `/userOrders`
+- [ ] Lowercase only — no camelCase in paths
+- [ ] Hyphens for multi-word segments — `/managed-devices` not `/managed_devices` or `/managedDevices`
+- [ ] No trailing slashes in route definitions
+- [ ] No file extensions — no `.json`, `.xml` in paths
+- [ ] Filtering, sorting, pagination in query params — not path segments
+
+### HTTP method semantics
+
+- [ ] GET handlers do not modify state — no writes, deletes, or side effects
+- [ ] POST used for creation of subordinate resources, not for generic "do this action"
+- [ ] PUT replaces the entire resource — not used for partial updates
+- [ ] PATCH used for partial updates — not PUT
+- [ ] DELETE removes the resource — not implemented as POST or GET
+- [ ] No action tunneling through GET query parameters (`?action=delete`)
+
+### Status codes
+
+- [ ] POST creating a resource returns `201 Created`, not `200 OK`
+- [ ] `201 Created` responses include a `Location` header pointing to the new resource
+- [ ] `204 No Content` responses have no body
+- [ ] `200 OK` is never returned for an error condition — errors use 4xx/5xx
+- [ ] `401 Unauthorized` includes a `WWW-Authenticate` header
+- [ ] `401` and `403` are not conflated — `401` = missing/invalid auth, `403` = insufficient permission
+- [ ] `405 Method Not Allowed` includes an `Allow` header listing supported methods
+- [ ] Validation failures return `422 Unprocessable Entity`, not `400 Bad Request`
+- [ ] `404` used for resources that don't exist; `410 Gone` for permanently deleted resources
+- [ ] `302 Found` not used for non-idempotent redirects — `307` preserves the method
+
+### Statelessness
+
+- [ ] No server-side session state between requests
+- [ ] Authentication carried in each request (Bearer token, API key) — not stored server-side
+- [ ] Handler functions do not read or write request-scoped state from a shared store
+
+### Caching headers
+
+- [ ] GET responses set `Cache-Control`, `ETag`, or `Last-Modified` where appropriate
+- [ ] Mutable operations (POST, PUT, PATCH, DELETE) do not return cacheable responses unless explicitly intended
+
+### Versioning
+
+- [ ] Breaking API changes are introduced under a new version prefix (`/v2/`)
+- [ ] Existing versioned URIs do not silently change behavior
+
+## Output format
+
+Organize findings into:
+
+- **Critical** — broken contracts: wrong status codes, GET with side effects, missing Location on 201, 200 masking errors. Must fix.
+- **Warning** — naming violations, method misuse, missing cache headers. Should fix.
+- **Suggestion** — hypermedia links, versioning improvements, optional improvements. Consider fixing.
+
+For each finding, include the file path, line number (if determinable), what the violation is, and the correct approach with a concrete example.

--- a/claude/.claude/rules/rest-api-conventions.md
+++ b/claude/.claude/rules/rest-api-conventions.md
@@ -1,0 +1,125 @@
+---
+paths:
+  - "**/*.go"
+  - "**/*.py"
+  - "**/*.ts"
+  - "**/*.js"
+  - "**/routes/**"
+  - "**/handlers/**"
+  - "**/controllers/**"
+  - "**/views/**"
+  - "**/api/**"
+---
+
+# REST API Conventions
+
+All REST API code must conform to the principles defined at https://restfulapi.net/. These are mandatory constraints, not suggestions.
+
+## Resource Naming
+
+- URIs identify resources — use nouns, never verbs
+- Collections use plural nouns: `/users`, `/managed-devices`
+- Documents (single resource) use singular nouns: `/users/{id}`, `/users/admin`
+- Hierarchical relationships use path segments: `/users/{id}/orders/{orderId}`
+- No verbs in URIs — HTTP methods are the verbs:
+  - `/users` not `/getUsers`
+  - `/users/{id}` not `/deleteUser/{id}`
+  - `/orders/{id}/cancel` is a violation — use `DELETE /orders/{id}` or model as a sub-resource
+- Lowercase letters only: `/managed-devices` not `/managedDevices`
+- Hyphens for readability, not underscores: `/managed-devices` not `/managed_devices`
+- No trailing slashes: `/users` not `/users/`
+- No file extensions: `/users` not `/users.json`
+- Query parameters for filtering, sorting, and pagination — not path segments:
+  - `/users?status=active&sort=name` not `/users/active/sorted-by-name`
+
+## HTTP Methods
+
+Use methods according to their defined semantics. Misuse is a contract violation.
+
+| Method | Semantics | Safe | Idempotent |
+|--------|-----------|------|------------|
+| GET    | Retrieve resource(s) — must not modify state | Yes | Yes |
+| POST   | Create a new subordinate resource | No | No |
+| PUT    | Replace an existing resource entirely | No | Yes |
+| PATCH  | Apply partial modifications to a resource | No | No* |
+| DELETE | Remove a resource | No | Yes |
+
+*PATCH idempotency depends on the operation — document intent explicitly.
+
+Rules:
+- GET must never modify server state — no side effects
+- POST creating a resource must return `201 Created` with a `Location` header
+- PUT must replace the entire resource representation — use PATCH for partial updates
+- Repeated PUT and DELETE requests must produce the same outcome as a single request
+- Do not tunnel actions through GET query parameters: `GET /users?action=delete` is forbidden
+
+## HTTP Status Codes
+
+Return the most specific applicable status code. Never hide errors in a `200 OK` response body.
+
+### Success (2xx)
+
+- `200 OK` — successful GET, PUT, PATCH, DELETE with response body
+- `201 Created` — resource created via POST; **must** include `Location` header with new resource URI
+- `202 Accepted` — request accepted but not yet processed (async operations)
+- `204 No Content` — successful PUT, PATCH, DELETE with no response body; **must not** include a body
+- `206 Partial Content` — response to a `Range` request
+
+### Redirection (3xx)
+
+- `301 Moved Permanently` — use sparingly; prefer API versioning (`/v1/`, `/v2/`) over redirects
+- `304 Not Modified` — use with `ETag`/`If-None-Match` or `Last-Modified`/`If-Modified-Since` for caching
+
+### Client Errors (4xx)
+
+- `400 Bad Request` — malformed syntax, invalid parameters; client must not repeat unchanged
+- `401 Unauthorized` — missing or invalid credentials; response must include `WWW-Authenticate` header
+- `403 Forbidden` — identity is known but access is denied; authentication will not help
+- `404 Not Found` — resource does not exist (may exist later); use `410 Gone` for permanently deleted
+- `405 Method Not Allowed` — HTTP method not supported; response must include `Allow` header
+- `406 Not Acceptable` — cannot produce the requested media type (`Accept` header)
+- `409 Conflict` — state conflict (e.g., duplicate create, optimistic locking failure)
+- `412 Precondition Failed` — conditional request headers (`If-Match`, etc.) not satisfied
+- `415 Unsupported Media Type` — cannot process the supplied `Content-Type`
+- `422 Unprocessable Entity` — syntax valid but semantically incorrect (validation errors)
+- `429 Too Many Requests` — rate limit exceeded
+
+### Server Errors (5xx)
+
+- `500 Internal Server Error` — unexpected server failure; never the client's fault
+- `503 Service Unavailable` — server temporarily unavailable; client may retry
+
+### Anti-Patterns (violations)
+
+- `200 OK` with an error message in the body — use the appropriate 4xx/5xx code
+- `201 Created` without a `Location` header
+- `204 No Content` with a response body
+- Conflating `401` and `403` — they have distinct meanings
+- Using `302 Found` for non-idempotent redirects — use `307 Temporary Redirect` to preserve method
+
+## Statelessness
+
+Every request must contain all information needed to process it. The server must not store client session state between requests.
+
+- Do not use server-side sessions to maintain client context
+- Authentication state must be carried in each request (e.g., Bearer token, API key)
+- Any state required between calls must be managed by the client
+
+## Uniform Interface
+
+- Each resource has a single, stable URI
+- Resources are manipulated through representations (JSON, XML) — not direct object references
+- Responses should include hypermedia links where they enable state transitions (HATEOAS)
+- Media type definitions describe how to process representations
+
+## Caching
+
+- Responses must explicitly indicate cacheability via `Cache-Control`, `ETag`, or `Last-Modified`
+- GET and HEAD responses are cacheable by default unless instructed otherwise
+- POST, PUT, PATCH, DELETE responses are not cacheable unless explicitly marked
+
+## Versioning
+
+- Version the API when breaking changes are introduced
+- Prefer URI path versioning: `/v1/users`, `/v2/users`
+- Do not silently change behavior under the same URI

--- a/claude/.claude/skills/review/SKILL.md
+++ b/claude/.claude/skills/review/SKILL.md
@@ -56,7 +56,7 @@ Report any lint errors under a **Lint** section before the per-file review. Exam
 
 Do not proceed to the semantic review until lint failures are resolved.
 
-### 4. Detect the Language
+### 4. Detect the Language and REST API Presence
 
 | Extension / Path | Reviewer Agent |
 |---|---|
@@ -67,11 +67,20 @@ Do not proceed to the semantic review until lint failures are resolved.
 | `skills/*/SKILL.md` | `skill-reviewer` |
 | Other | Review inline: general quality, security (OWASP Top 10), readability |
 
+**Additionally**, detect whether any changed files define HTTP endpoints. A file defines HTTP endpoints if it matches any of these patterns:
+
+- Contains route registrations: `router.GET`, `router.POST`, `app.get(`, `@app.route`, `http.HandleFunc`, `mux.Handle`, `router.Handle`, `APIRouter()`, `@router.get`, `@router.post`, `r.GET`, `r.POST`, `r.PUT`, `r.PATCH`, `r.DELETE`
+- Lives under a path matching `**/routes/**`, `**/handlers/**`, `**/controllers/**`, `**/views/**`, `**/api/**`
+
+If REST API patterns are detected, invoke `rest-reviewer` on those files **in addition to** the language-specific agent.
+
 ### 5. Delegate to Reviewer Agents
 
 For each language group, invoke the appropriate reviewer agent. Pass it the specific files to review.
 
 The agents check against their full language-specific criteria (conventions, architecture, error handling, idioms, testing) and return structured findings organized by severity.
+
+If `rest-reviewer` was triggered, run it against the files containing HTTP endpoint definitions. Merge its findings into the per-file report under a `### REST API` subsection.
 
 For non-code files (config, YAML, Markdown), review inline:
 - **Security**: injection risks, hardcoded credentials, sensitive data exposure


### PR DESCRIPTION
## Summary
- New rule `rest-api-conventions.md` codifies all standards from https://restfulapi.net/
- New agent `rest-reviewer.md` reviews HTTP handler/route code against those standards
- Updated `/review` skill to auto-detect REST API patterns and invoke `rest-reviewer`

## Motivation
No Claude components existed to enforce REST API standards. Language-specific reviewers (go-reviewer, py-reviewer) catch idiomatic and architectural issues but have no knowledge of REST contracts — URI naming, HTTP method semantics, status code correctness, statelessness, or caching. Any API handler would pass review with wrong status codes or verb-in-URI violations.

## Changes
- `rules/rest-api-conventions.md`: Language-agnostic rule covering resource naming, HTTP method semantics, status code contracts, statelessness, caching, and versioning — grounded in restfulapi.net
- `agents/rest-reviewer.md`: Reviewer agent with a full checklist; reports Critical/Warning/Suggestion findings; invoked by `/review` when REST patterns are detected
- `skills/review/SKILL.md`: Added REST API detection step — scans for route registration patterns and API path conventions; invokes `rest-reviewer` in addition to the language-specific agent when matches found

## Test Plan
- [ ] Run `/review` on a Go file with `router.GET`/`router.POST` — confirm `rest-reviewer` is invoked
- [ ] Run `/review` on a Python FastAPI file — confirm REST findings appear alongside Python findings
- [ ] Introduce a deliberate violation (verb in URI, missing Location on 201) — confirm it's flagged as Critical
- [ ] Run `/review` on a non-API file (domain logic, utility) — confirm `rest-reviewer` is NOT invoked