### PR TITLE
fix(skills): keep uv.lock in sync across ship and main

### DIFF
--- a/claude/.claude/skills/main/SKILL.md
+++ b/claude/.claude/skills/main/SKILL.md
@@ -12,8 +12,10 @@ Use this skill when the user wants to switch to the main branch and sync it with
 
 1. Run `git checkout main`
 2. Run `git pull origin main`
-3. Delete merged local branches: `git branch --merged main | grep -v '^\*\|main\|master' | xargs -r git branch -d`
-4. Report the result — current branch, the pull output (fast-forward, already up to date, etc.), and any branches that were deleted
+3. If `uv.lock` exists: run `uv lock` to re-sync the lockfile with any version bump
+   that the release workflow may have committed to main. Report if `uv.lock` changed.
+4. Delete merged local branches: `git branch --merged main | grep -v '^\*\|main\|master' | xargs -r git branch -d`
+5. Report the result — current branch, the pull output (fast-forward, already up to date, etc.), and any branches that were deleted
 
 ## Rules
 
@@ -21,3 +23,4 @@ Use this skill when the user wants to switch to the main branch and sync it with
 - If `main` does not exist but `master` does, use `master` instead
 - Always report the final state: current branch and whether the pull brought in new commits
 - If no merged branches were found to delete, omit that from the report (don't mention it)
+- After `uv lock`, leave `uv.lock` as an unstaged change — do not commit it automatically

--- a/claude/.claude/skills/ship/SKILL.md
+++ b/claude/.claude/skills/ship/SKILL.md
@@ -84,7 +84,7 @@ Before touching git, run the project's lint/format checks. Detect what's availab
 
 | Tool | Command |
 |------|---------|
-| uv lockfile | If `uv.lock` exists: always run `uv lock` to sync it, then stage `uv.lock` before continuing |
+| uv lockfile | If `uv.lock` exists: run `uv lock` to sync it, then **always** run `git add uv.lock` — even if `uv lock` produced no new changes, because the file may already carry an unstaged modification from a prior sync that must be included in the commit |
 | ruff | `ruff check . && ruff format --check .` |
 | flake8 | `flake8 .` |
 | eslint | `npx eslint .` |


### PR DESCRIPTION
## Summary
- `/ship` now always stages `uv.lock` after running `uv lock`, even when `uv lock` produces no new changes
- `/main` now runs `uv lock` after `git pull` to re-sync the lockfile with any version bump committed by the release workflow

## Motivation
After a PR merges and the release workflow bumps the version, the local `uv.lock` drifts out of sync with `pyproject.toml`. This showed up as a persistent unstaged `uv.lock` modification at the start of every new session. The root cause was two gaps: `/ship` skipped staging `uv.lock` when `uv lock` made no new changes, and `/main` never re-synced the lockfile after pulling.

## Changes
- `claude/.claude/skills/ship/SKILL.md`: clarify that `git add uv.lock` must always run after `uv lock`, not only when `uv lock` modifies the file
- `claude/.claude/skills/main/SKILL.md`: add step to run `uv lock` after `git pull`; add rule to leave the result as unstaged (not auto-committed)

## Test Plan
- [ ] Run `/ship` on a branch where `uv.lock` has an unstaged modification — confirm it is included in the commit
- [ ] Run `/main` after a release bump — confirm `uv.lock` is re-synced automatically with no manual intervention