### PR TITLE
fix(skills): handle squash-merged branches in /main cleanup

### DIFF
--- a/claude/.claude/skills/main/SKILL.md
+++ b/claude/.claude/skills/main/SKILL.md
@@ -14,7 +14,9 @@ Use this skill when the user wants to switch to the main branch and sync it with
 2. Run `git pull origin main`
 3. If `uv.lock` exists: run `uv lock` to re-sync the lockfile with any version bump
    that the release workflow may have committed to main. Report if `uv.lock` changed.
-4. Delete merged local branches: `git branch --merged main | grep -v '^\*\|main\|master' | xargs -r git branch -d`
+4. Delete merged local branches using a two-pass approach:
+   - **Pass 1 — fast-forward merges**: `git branch --merged main | grep -v '^\*\|main\|master' | xargs -r git branch -d`
+   - **Pass 2 — squash/rebase merges**: for any branch that `-d` skipped (the error lists them), check if a PR was merged for that branch with `gh pr list --state merged --head <branch>`. If a merged PR exists, force-delete with `git branch -D <branch>`. If no merged PR exists, leave the branch alone and report it to the user.
 5. Report the result — current branch, the pull output (fast-forward, already up to date, etc.), and any branches that were deleted
 
 ## Rules


### PR DESCRIPTION
## Summary
- `/main` now handles branches merged via squash or rebase, which `git branch -d` silently skips
- Adds a second pass using `gh pr list --state merged` to confirm before force-deleting with `-D`

## Motivation
`git branch -d` only deletes branches whose commits appear verbatim in main's history. Squash and rebase merges rewrite SHAs, so git refuses to delete those branches even though the work is already in main. This caused a spurious error on every `/main` run when stale squash-merged branches existed locally.

## Changes
- `skills/main/SKILL.md` — replaced single `-d` pass with two-pass cleanup: `-d` for fast-forward merges, then `gh pr list --state merged` check before `-D` for squash/rebase merges

## Test Plan
- [ ] Create a branch, merge it via squash PR, run `/main` — verify branch is deleted cleanly
- [ ] Create a branch with no PR, run `/main` — verify branch is left alone and reported