### PR TITLE
feat(skills/dir): expand /dir output to list modified files

### DIFF
--- a/claude/.claude/skills/dir/SKILL.md
+++ b/claude/.claude/skills/dir/SKILL.md
@@ -46,10 +46,16 @@ Output the report in this exact format:
 ```
 **Directory:** <absolute path>
 **Project:** <type from step 2>
-**Branch:** <branch name> (<clean> or <N files changed>)
+**Branch:** <branch name>
+
+Modified files:
+  M path/to/changed-file.go
+  ?? path/to/untracked-file.go
 ```
 
-If not in a git repo, omit the Branch line.
+If there are no modified or untracked files, replace the file list with `(clean)`.
+
+If not in a git repo, omit the Branch line and the modified files section.
 
 ### 5. Verify
 


### PR DESCRIPTION
## Summary
- `/dir` now shows each modified and untracked file on its own line instead of a count

## Motivation
The previous output (`<N files changed>` inline) gave a count but no names, requiring a separate `git status` to know what was actually pending. The new format surfaces the paths directly so the state of the working tree is immediately visible after `/dir`.

## Changes
- Branch line no longer includes the file count inline
- New `Modified files:` block lists each changed path with its git status prefix (`M`, `??`, etc.)
- Clean working trees show `(clean)` in place of the file list
- Non-git directories omit the branch and modified files sections entirely

## Test Plan
- [ ] Run `/dir` in a repo with staged and untracked files — confirm each file is listed
- [ ] Run `/dir` in a clean repo — confirm `(clean)` is shown
- [ ] Run `/dir` outside a git repo — confirm branch and file sections are absent