### PR TITLE
feat(skills/ship): add multi-PR grouping to /ship

### DIFF
--- a/claude/.claude/skills/ship/SKILL.md
+++ b/claude/.claude/skills/ship/SKILL.md
@@ -83,6 +83,48 @@ After pushing (`git push -u origin <branch>`), run `gh pr create` to open a new 
 - Read any relevant files needed to write an accurate commit message and PR description
 - Identify the type of change: new feature, bug fix, refactor, etc.
 
+### 1.5. Group Changes into PRs
+
+Analyze whether the working-tree changes span multiple conceptual areas. A group is a set of files that share the same intent and a single conventional-commit type+scope.
+
+**Split signals** — treat these as separate groups:
+- Different commit types (e.g., `feat` vs `fix` vs `docs` vs `chore`)
+- Different scopes within the same type (e.g., `feat(auth)` vs `feat(api)`)
+- Files that are logically unrelated (e.g., a new CLI flag + an unrelated bug fix + doc updates)
+- Changes in independent modules that have no runtime dependency on each other
+
+**Keep together** — do NOT split when:
+- All changed files implement the same feature end-to-end (handler + model + test for one feature)
+- A fix and its test live in the same scope
+- A refactor touches multiple files but has a single unified intent
+
+**If a single group covers all changes**, proceed as one PR (existing behavior).
+
+**If multiple groups are identified**, present the proposed split to the user:
+
+```
+I found 3 conceptual groups in the working tree. I'll ship them as separate PRs:
+
+  1. feat(auth): add OAuth2 token refresh  →  feature/add-oauth2-token-refresh
+     Files: internal/auth/token.go, internal/auth/token_test.go
+
+  2. fix(api): correct 404 on missing resource  →  hotfix/fix-404-on-missing-resource
+     Files: internal/api/handler.go
+
+  3. docs: update README with new auth flow  →  feature/update-readme-auth-flow
+     Files: README.md
+
+Proceed with all 3, or adjust the grouping?
+```
+
+Wait for explicit user confirmation before proceeding. The user may regroup, merge, or drop entries.
+
+Once confirmed, process each group sequentially through steps 2–9. For each group:
+- Stage **only the files in that group** — never `git add -A` across groups
+- Create its own branch from the latest `main`
+- Commit, push, and open a PR for that group
+- Report the PR URL before starting the next group
+
 ### 2. Pre-flight: Lint
 
 Before touching git, run the project's lint/format checks. Detect what's available and run all that apply:
@@ -252,3 +294,7 @@ Report the pushed commit hash and message. Do not open a PR.
 - Use the conventional-commits rule for all commit messages
 - If the current branch is active and unmerged, always commit to it — never create a new branch
 - If the current branch has already been merged into main, check out main and start a fresh branch — never commit to a merged branch
+- In multi-PR mode, always branch each group from the latest `main` — never base one group's branch on another group's branch
+- In multi-PR mode, never stage files from a different group — one group's files must not appear in another group's commit
+- Lint and tests must pass before the first group is committed; do not re-run them between groups unless a group's files include build or config changes that could affect them
+- `-m` always ships as a single commit to main regardless of how many groups are detected — multi-PR grouping does not apply


### PR DESCRIPTION
## Summary
- `/ship` now analyzes the working tree before acting and proposes splitting unrelated changes into separate PRs
- Each group gets its own branch, commit, and PR with an appropriate conventional-commit type and scope

## Motivation
Shipping everything in one PR whenever multiple unrelated changes are present obscures intent, makes reviews harder, and couples unrelated work in git history. Small, focused PRs per conceptual area are easier to review and revert.

## Changes
- New step 1.5 analyzes changes by commit type and scope to identify conceptual groups
- Defines explicit split signals (different types, different scopes, unrelated modules) and keep-together signals (end-to-end feature, fix+test, unified refactor)
- Presents a proposed split to the user with branch names and file lists before proceeding
- Processes each confirmed group sequentially: branch from `main`, stage only its files, commit, push, open PR, report URL
- New rules enforce group isolation: no cross-group staging, always branch from `main`, lint/tests run once before group 1
- `-m` flag bypasses grouping entirely (single commit to main)

## Test Plan
- [ ] Run `/ship` with changes spanning two different commit types — confirm proposed split is shown
- [ ] Confirm each group creates its own branch from `main`
- [ ] Confirm files from group 1 do not appear in group 2's commit
- [ ] Run `/ship` with a single cohesive change — confirm no split is proposed
- [ ] Run `/ship -m` with mixed changes — confirm single commit, no grouping