### PR TITLE
feat(hooks): add conflict-check hook and pr-discipline workflow rule

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -22,3 +22,17 @@ Always ensure `TODO.md` is listed in the repo's `.gitignore`. If it isn't, add i
 
 Always use Conventional Commits: `<type>(<scope>): <description>` — lowercase, imperative mood, no period.
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`. Breaking changes use `!` and a `BREAKING CHANGE:` footer.
+
+# PR Discipline
+
+One PR = one `type(scope)` pair. Before creating a branch, committing, or pushing, ask: "Can I describe all of these changes with a single conventional commit subject line?" If the answer contains "and" — there are mixed concerns that must be split.
+
+**When starting work:** name the branch after the intended commit (e.g. `chore/remove-junitxml`, `test/bdd-v2-steps`) before touching any files. Don't let unrelated changes accumulate on the same branch.
+
+**When mixed concerns are detected mid-stream:**
+1. Stash all uncommitted changes: `git stash push -u -m "split: <description>"`
+2. Create one branch from `main` per concern
+3. Apply only the relevant files to each branch from the stash
+4. Each branch gets its own PR targeting `main`
+
+**Before pushing:** run `git fetch origin main` and check whether the files you changed also changed on main since the branch diverged. If they did, rebase before opening the PR: `git rebase origin/main`.

--- a/claude/.claude/hooks/conflict-check.sh
+++ b/claude/.claude/hooks/conflict-check.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# PreToolUse hook: warn Claude when files changed on this branch also changed on
+# origin/main since the branch diverged — surfaces potential merge conflicts
+# before the push, so a rebase can happen first.
+#
+# Outputs additionalContext JSON (non-blocking) when overlap is found.
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only relevant for git push
+[[ "$COMMAND" != *"git push"* ]] && exit 0
+
+# protect-main.sh handles the main/master case; skip here
+BRANCH=$(cd "${CLAUDE_PROJECT_DIR:-.}" && git branch --show-current 2>/dev/null)
+[[ "$BRANCH" == "main" || "$BRANCH" == "master" ]] && exit 0
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+# Fetch silently — a stale origin/main is a false negative
+git fetch origin main --quiet 2>/dev/null || exit 0
+
+MERGE_BASE=$(git merge-base HEAD origin/main 2>/dev/null) || exit 0
+[[ -z "$MERGE_BASE" ]] && exit 0
+
+# Files this branch changed since it diverged from main
+BRANCH_FILES=$(git diff --name-only "$MERGE_BASE" HEAD 2>/dev/null | sort -u)
+[[ -z "$BRANCH_FILES" ]] && exit 0
+
+# Files main changed since the branch diverged
+MAIN_FILES=$(git diff --name-only "$MERGE_BASE" origin/main 2>/dev/null | sort -u)
+[[ -z "$MAIN_FILES" ]] && exit 0
+
+OVERLAP=$(comm -12 <(echo "$BRANCH_FILES") <(echo "$MAIN_FILES") 2>/dev/null)
+[[ -z "$OVERLAP" ]] && exit 0
+
+FILES_LIST=$(echo "$OVERLAP" | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+echo "{\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"additionalContext\": \"Conflict warning: the following files were also modified on origin/main since this branch diverged — $FILES_LIST — rebase before opening the PR to avoid merge conflicts: git rebase origin/main\"}}"
+
+exit 0

--- a/claude/.claude/hooks/lint.sh
+++ b/claude/.claude/hooks/lint.sh
@@ -21,6 +21,29 @@ case "${FILE##*.}" in
     command -v ruff &>/dev/null || exit 0
     echo "$HOOK ruff: checking $FILE" >&2
     ruff check --quiet "$FILE" >&2 && ruff format --check --quiet "$FILE" >&2
+    # Complexity check — skip test files (they're excluded from CI complexity gate too)
+    [[ "$FILE" == */test_*.py || "$FILE" == *_test.py || "$FILE" == */tests/* ]] && exit 0
+    # Walk up to the project root (where pyproject.toml lives)
+    PROJ_DIR="$(dirname "$FILE")"
+    while [[ "$PROJ_DIR" != "/" && ! -f "$PROJ_DIR/pyproject.toml" ]]; do
+      PROJ_DIR="$(dirname "$PROJ_DIR")"
+    done
+    [[ ! -f "$PROJ_DIR/pyproject.toml" ]] && exit 0
+    # Skip if cyclo isn't installed in this project
+    (cd "$PROJ_DIR" && uv run cyclo --help &>/dev/null 2>&1) || exit 0
+    # Read threshold from pyproject.toml [tool.ruff.lint.mccabe] max-complexity, default 7
+    MAX_C=$(grep -A2 '\[tool\.ruff\.lint\.mccabe\]' "$PROJ_DIR/pyproject.toml" 2>/dev/null \
+      | grep 'max-complexity' | grep -oE '[0-9]+' | head -1)
+    MAX_C="${MAX_C:-7}"
+    FILE_DIR="$(dirname "$FILE")"
+    REL_DIR="${FILE_DIR#${PROJ_DIR}/}"
+    echo "$HOOK cyclo: checking complexity (max $MAX_C) in $REL_DIR" >&2
+    CYCLO_OUT=$(cd "$PROJ_DIR" && uv run cyclo -m "$MAX_C" "$FILE_DIR" 2>&1)
+    CYCLO_EXIT=$?
+    if [[ $CYCLO_EXIT -ne 0 ]]; then
+      echo "$CYCLO_OUT" >&2
+      exit $CYCLO_EXIT
+    fi
     ;;
   go)
     echo "$(date -u +%FT%TZ) $HOOK go: $FILE" >> "$LOG"

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -127,6 +127,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/protect-main.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/conflict-check.sh"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Adds `claude/.claude/hooks/conflict-check.sh` — a `PreToolUse` hook that fires before every `git push`
- Wires the hook into the `Bash(git push:*)` block in `settings.json`
- Adds a **PR Discipline** section to `CLAUDE.md`

## Motivation
Working on PRs that tangled multiple concerns (e.g. a deps bump, an infra cleanup, and new test steps all on one branch) made it necessary to enforce two disciplines automatically:

1. **Conflict detection** — catch when files changed on a feature branch also changed on `main` since the branch diverged, so a rebase happens before the PR is opened rather than at review time
2. **PR discipline** — encode the rule that one PR = one `type(scope)` pair, with a documented stash-split-apply procedure for untangling mixed-concern branches mid-stream

## Changes
- `conflict-check.sh`: fetches `origin/main`, computes the merge base, diffs both sides, and injects `additionalContext` into Claude's context listing any overlapping files — non-blocking, warn-only
- `settings.json`: adds `conflict-check.sh` alongside `protect-main.sh` in the `Bash(git push:*)` PreToolUse hook block
- `CLAUDE.md`: new **PR Discipline** section with the one-PR-per-type-scope rule and the step-by-step split procedure

## Test Plan
- [ ] Trigger a `git push` on a branch where overlapping files exist on main — verify the warning appears in Claude's context
- [ ] Trigger a `git push` on a clean branch — verify no warning is emitted
- [ ] Confirm `bash -n conflict-check.sh` passes (syntax check)