### PR TITLE
chore(claude): apply workflow-audit optimizations

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -1,3 +1,9 @@
+# Development Workflow
+
+Run `/workflow` to see the complete development workflow reference (architect → implement → review → ship).
+
+---
+
 # Context-First Development
 
 The mark of a high-quality codebase is that it explains its *reasoning*, not just its behavior — it communicates **why**, not just **what**.

--- a/claude/.claude/commands/workflow.md
+++ b/claude/.claude/commands/workflow.md
@@ -14,7 +14,7 @@ Invoke for anything beyond a trivial change: new packages, significant new abstr
 ### 2. `/*-feature` — implement with TDD
 Use `/go-feature`, `/py-feature`, `/nvim-feature`, or `/gherkin-feature`. The `tdd` rule auto-invokes `/test-driven-development` (red-green-refactor). The lint hook runs automatically after every file save.
 
-### 3. `/review` — catch issues before shipping
+### 3. `/code-review` — catch issues before shipping
 Delegates to `go-reviewer`, `py-reviewer`, `nvim-reviewer`, or `gherkin-reviewer` agents for deep, criteria-driven review. The `review-on-implement` rule suggests this after significant implementation.
 
 ### 4. `/ship` — branch, commit, push, open PR
@@ -41,7 +41,7 @@ Checkout main, pull latest, delete merged branches.
 | Deprecated API calls | `/migrate` | Suggested by `migrate-suggest` rule when old patterns detected |
 | Structural design issues | `/refactor` | Go, Python, and Neovim supported |
 | Missing documentation | `/go-docs` / `/py-docs` / `/nvim-docs` / `/gherkin-docs` | Suggested by `docs-suggest` rule when public API added without docs |
-| Post-review code quality | `/simplify` | After `/review` to apply fixes for reuse, quality, and efficiency |
+| Post-review code quality | `/simplify` | After `/code-review` to apply fixes for reuse, quality, and efficiency (team plugin — not in dotfiles) |
 | Go performance analysis | `/go-bench` | When benchmarking Go code or investigating allocations and throughput |
 
 ---
@@ -90,6 +90,6 @@ These run without being asked:
 | Rule | Fires when | Suggests |
 |---|---|---|
 | `tdd` | Implementing new features or bug fixes | `/test-driven-development` skill |
-| `review-on-implement` | After significant implementation | `/review` |
+| `review-on-implement` | After significant implementation | `/code-review` |
 | `docs-suggest` | Public API added without documentation | `/go-docs`, `/py-docs`, or `/nvim-docs` |
 | `migrate-suggest` | Deprecated patterns detected in edited files | `/migrate` |

--- a/claude/.claude/hooks/tdd-remind.sh
+++ b/claude/.claude/hooks/tdd-remind.sh
@@ -25,4 +25,9 @@ case "$FILE" in
   */tests/*|*/test/*) exit 0 ;;
 esac
 
+# Skip Neovim config files — pure configuration, no testable behavior
+case "$FILE" in
+  */lua/config/*.lua|*/lua/plugins/*.lua|*/lsp/*.lua|*/after/ftplugin/*.lua) exit 0 ;;
+esac
+
 echo "[hook: tdd-remind] TDD REQUIRED: Write a failing test, run it, show failure output — THEN edit ${FILE}. Exceptions: /migrate, /refactor, or purely mechanical renames only."

--- a/claude/.claude/rules/review-on-implement.md
+++ b/claude/.claude/rules/review-on-implement.md
@@ -8,9 +8,9 @@ paths:
 
 # Always Recommend Review After Implementation
 
-After completing a significant implementation task — a new feature, bug fix, or substantial refactor — always recommend running `/review` before shipping. Do not skip this recommendation; unreviewed code is the primary source of regressions and missed issues.
+After completing a significant implementation task — a new feature, bug fix, or substantial refactor — always recommend running `/code-review` before shipping. Do not skip this recommendation; unreviewed code is the primary source of regressions and missed issues.
 
-**Always recommend `/review` when:**
+**Always recommend `/code-review` when:**
 - A new function, class, module, or package has been written
 - A bug fix that touches more than one file
 - A refactor that moves or restructures code
@@ -18,7 +18,7 @@ After completing a significant implementation task — a new feature, bug fix, o
 **Do not recommend when:**
 - Single-line fixes (typo correction, comment update, minor rename)
 - Changes to config, documentation, or non-code files only
-- The user has already run `/review` in this session for these files
+- The user has already run `/code-review` in this session for these files
 
 Keep the recommendation brief: one line at the end of your response, e.g.:
-> Run `/review` before shipping to catch any issues.
+> Run `/code-review` before shipping to catch any issues.

--- a/claude/.claude/skills/audit/SKILL.md
+++ b/claude/.claude/skills/audit/SKILL.md
@@ -86,3 +86,7 @@ Do not make any changes until the user confirms.
 - Do not report issues that were already fixed in the current session
 - Distinguish clearly between "this is broken" (correctness) and "this could be better" (polish)
 - If the system looks genuinely well-optimized, say so — do not manufacture findings
+
+## Related
+
+For auditing individual `SKILL.md` files against structural conventions, use `/skill-audit` instead — it runs `skill-reviewer` on each skill file and is scoped to skill quality, not system-wide integration.

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -11,13 +11,13 @@ Use this skill when you want an explicit, structured review of changed or specif
 ## Usage
 
 ```
-/review                    # review all files changed since last commit
-/review <file-or-glob>     # review specific files
-/review HEAD~3             # review all changes in the last 3 commits
-/review -f                  # review + automatically fix all Must Fix and Should Fix findings
-/review -f <file-or-glob>   # same, scoped to specific files
-/review -fc                 # review + fix + repeat until no findings remain
-/review -fc <file-or-glob>  # same, scoped to specific files
+/code-review                    # review all files changed since last commit
+/code-review <file-or-glob>     # review specific files
+/code-review HEAD~3             # review all changes in the last 3 commits
+/code-review -f                 # review + automatically fix all Must Fix and Should Fix findings
+/code-review -f <file-or-glob>  # same, scoped to specific files
+/code-review -fc                # review + fix + repeat until no findings remain
+/code-review -fc <file-or-glob> # same, scoped to specific files
 ```
 
 - `-f` — fix all findings once, then stop

--- a/claude/.claude/skills/gherkin-feature/SKILL.md
+++ b/claude/.claude/skills/gherkin-feature/SKILL.md
@@ -47,14 +47,8 @@ paths:
 - Configure environment (base URLs, credentials, browser setup)
 - Add custom parameter types for domain concepts
 
-### 6. Review Checklist
+### 6. Review
 
-- [ ] Feature describes behavior, not implementation
-- [ ] Each scenario is independent — no ordering dependencies
-- [ ] Steps are declarative — no UI mechanics or implementation details
-- [ ] One When step per scenario
-- [ ] Background contains only Given steps shared by all scenarios
-- [ ] Scenario Outlines have meaningful variation in Examples
-- [ ] Step definitions are thin — logic delegated to helpers
-- [ ] Tags applied for filtering (`@smoke`, `@slow`, domain tags)
-- [ ] Feature file ≤ 10 scenarios
+Invoke the `gherkin-reviewer` agent on the new feature file and step definitions. Fix all Critical and Warning findings before marking the task complete.
+
+Run `/code-review` before shipping to catch any issues.

--- a/claude/.claude/skills/skill-audit/SKILL.md
+++ b/claude/.claude/skills/skill-audit/SKILL.md
@@ -70,3 +70,7 @@ Do not batch multiple skills into one commit — it makes it harder to revert a 
 - Do not skip any skill file found in step 1 — a partial audit is misleading
 - Do not auto-fix without confirming with the user first
 - Report findings even if the skill is rarely used — silent debt accumulates
+
+## Related
+
+For a system-wide audit of how all components (hooks, rules, agents, skills, settings) integrate with each other, use `/audit` instead — it covers inter-component correctness, redundancy, and coverage gaps, not individual skill file quality.

--- a/claude/.claude/skills/test-driven-development/SKILL.md
+++ b/claude/.claude/skills/test-driven-development/SKILL.md
@@ -1,10 +1,7 @@
 ---
-description: Enforces test-driven development when writing, modifying, or fixing code. Auto-invoked for implementation tasks.
-paths:
-  - "**/*.py"
-  - "**/*.go"
-  - "**/*.lua"
-  - "**/*.feature"
+description: Deep TDD reference — red-green-refactor cycle, language-specific tooling, and anti-patterns. Auto-triggered guidance lives in rules/tdd.md; invoke /tdd for the full reference.
+triggers:
+  - /tdd
 ---
 
 # Test-Driven Development


### PR DESCRIPTION
## Summary
- Fix stale `/review` references (4 locations) left after the skill rename to `/code-review`
- Remove TDD triple-redundancy: skill no longer auto-triggers via `paths:`, only user-invocable via `/tdd`
- Exclude Neovim config files from `tdd-remind.sh` hook — pure configuration has no testable behavior
- Replace inline review checklist in `gherkin-feature` with `gherkin-reviewer` agent delegation, consistent with `go-feature` and `py-feature`
- Add bidirectional cross-references between `/audit` and `/skill-audit` skills
- Surface `/workflow` command reference at the top of `CLAUDE.md` for discoverability

## Motivation
A full workflow audit (`/audit`) identified 8 findings across Correctness, Redundancy, Missing Connections, and Discoverability categories. This PR implements the 6 findings that touch the core workflow configuration. The remaining 2 are shipped separately (`feat(ship)` and `feat(commands)`).

## Changes
- `CLAUDE.md` — add Development Workflow section pointing to `/workflow`
- `commands/workflow.md` — update step 3 heading and rules table to `/code-review`
- `hooks/tdd-remind.sh` — add Neovim config path exclusions
- `rules/review-on-implement.md` — replace all `/review` with `/code-review`
- `skills/audit/SKILL.md` — add `## Related` cross-reference to `/skill-audit`
- `skills/code-review/SKILL.md` — fix Usage section commands from `/review` to `/code-review`
- `skills/gherkin-feature/SKILL.md` — replace step 6 checklist with `gherkin-reviewer` agent delegation
- `skills/skill-audit/SKILL.md` — add `## Related` cross-reference to `/audit`
- `skills/test-driven-development/SKILL.md` — remove `paths:` block, add `/tdd` trigger

## Test Plan
- [ ] Verify `/code-review` autocompletes correctly (not `/review`)
- [ ] Confirm `review-on-implement` rule recommends `/code-review` in session
- [ ] Edit a Neovim config file (e.g. `lua/config/options.lua`) — `tdd-remind` hook should not fire
- [ ] Edit a `.go` or `.py` file — `tdd-remind` hook should still fire
- [ ] Run `/tdd` — should invoke the skill; confirm no auto-trigger on file edits
- [ ] Run `/audit` — should see `## Related` pointing to `/skill-audit`
- [ ] Run `/skill-audit` — should see `## Related` pointing to `/audit`