### PR TITLE
feat(hooks/lint): add shellcheck coverage for shell script files

### DIFF
--- a/claude/.claude/hooks/lint.sh
+++ b/claude/.claude/hooks/lint.sh
@@ -155,6 +155,12 @@ case "${FILE##*.}" in
         ;;
     esac
     ;;
+  sh)
+    echo "$(date -u +%FT%TZ) $HOOK sh: $FILE" >> "$LOG"
+    command -v shellcheck &>/dev/null || exit 0
+    echo "$HOOK shellcheck: checking $FILE" >&2
+    shellcheck "$FILE" >&2
+    ;;
   *)
     exit 0
     ;;


### PR DESCRIPTION
## Summary
- Add a `sh` case to `hooks/lint.sh` that runs `shellcheck` when available

## Motivation
`lint.sh` already covers `.py`, `.go`, `.lua`, `.feature`, `.toml`, and `.yml` files but had no handler for `.sh` files. All other hook scripts in this repo are shell scripts, so edits to hooks were silently passing through the lint gate without any static analysis. The new `sh` case follows the same graceful-skip pattern as other optional tools — if `shellcheck` is not installed, the hook exits cleanly.

## Changes
- `hooks/lint.sh`: add `sh)` case before the catch-all `*)`

## Test Plan
- [ ] Edit any `.sh` file in `hooks/` — confirm shellcheck fires if installed, exits 0 if not installed
- [ ] Confirm no regression on `.py`, `.go`, `.lua` edits