### PR TITLE
fix(rules): address third-audit correctness and redundancy findings

### DIFF
--- a/claude/.claude/rules/py-conventions.md
+++ b/claude/.claude/rules/py-conventions.md
@@ -20,17 +20,7 @@ paths:
 
 ## Design Patterns
 
-Use Gang of Four patterns where they reduce complexity:
-
-- Strategy for variant behavior (prefer callables or Protocol classes)
-- Adapter to wrap external clients and SDKs
-- Facade to simplify multi-step workflows
-- Factory for object creation with complex setup
-- Observer/Pub-Sub for event-driven decoupling
-- Decorator for cross-cutting concerns (logging, caching, retry)
-- Command for encapsulating operations
-
-Do not force a pattern where a simple function will do.
+See `rules/design-patterns-application.md` for GoF pattern guidance including Python-specific notes for each pattern.
 
 ## Architecture (Server Applications)
 

--- a/claude/.claude/rules/readme-learnings.md
+++ b/claude/.claude/rules/readme-learnings.md
@@ -41,8 +41,8 @@ Do not pad entries. If the lesson can be stated in one sentence, use one sentenc
 
 1. Read the current `README.md`
 2. Add the new entry under the appropriate section (or create a new section if none fits)
-3. Commit with: `docs(claude): add learning — <one-line summary>`
-4. Push to main immediately — do not batch learnings across sessions
+3. Run `/ship -m` to commit directly to main and push without a PR — use commit message `docs(claude): add learning — <one-line summary>`
+4. Do not batch learnings across sessions — ship immediately after each session that produced a new learning
 
 ## Sections in README.md
 


### PR DESCRIPTION
## Summary
- Fix `readme-learnings.md`: step 4 instructed direct `git push origin main`, which `protect-main.sh` blocks — every learning session silently failed to document the finding
- Fix `py-conventions.md`: inline GoF pattern guidance duplicated `rules/design-patterns-application.md`, creating two sources of truth that could drift

## Motivation
Third audit cycle identified these as correctness and redundancy findings. The readme-learnings issue caused silent documentation failures — the entire purpose of that rule was undermined by the conflicting instruction.

## Changes
- `rules/readme-learnings.md`: replaced step 4 raw git commands with `/ship -m` (exactly what that flag is for — trivial docs/config commits to main without a PR)
- `rules/py-conventions.md`: removed the inline 7-item GoF pattern list; replaced with a single reference line pointing to `rules/design-patterns-application.md`

## Test Plan
- [ ] Trigger `readme-learnings` rule in a session — verify it attempts `/ship -m` not `git push origin main`
- [ ] Verify `py-conventions.md` no longer lists GoF patterns inline; `design-patterns-application.md` is the single source of truth