### PR TITLE
fix(commands/bdd): add SUN repo structure guard

### DIFF
--- a/claude/.claude/commands/bdd.md
+++ b/claude/.claude/commands/bdd.md
@@ -52,6 +52,7 @@ Run a BDD feature file's pytest stub with the correct environment and region.
    ```bash
    find features/ -name "<feature_name>.feature" 2>/dev/null
    ```
+   - If `features/` does not exist in the current directory: report "This command requires a SUN acceptance test repo layout (`features/` and `tests/bdd/`). Not found in current directory." and stop.
    - If zero results: report "No feature file named `<feature_name>.feature` found under features/." and stop.
    - If multiple results: list them and ask the user which one to use.
 


### PR DESCRIPTION
## Summary
- Add a guard to `/bdd` that detects non-SUN project layouts before attempting to locate feature files

## Motivation
`/bdd` hardcodes `features/` and `tests/bdd/` directory paths — the SUN acceptance test repo layout — but lives in global dotfiles. Without a guard, running `/bdd` in any other project silently does `find features/` and reports "No feature file found" with no indication the command is repo-specific. This is a confusing and misleading failure mode.

## Changes
- `commands/bdd.md` step 2: added a check — if `features/` does not exist in the current directory, report a clear message ("This command requires a SUN acceptance test repo layout") and stop before doing anything

## Test Plan
- [ ] Run `/bdd foo` in a non-SUN project — verify the guard message appears and command stops
- [ ] Run `/bdd foo` in a SUN acceptance test repo — verify normal operation continues