### PR TITLE
docs(workflow): add /work and /here-now to workflow reference

### DIFF
--- a/claude/.claude/commands/workflow.md
+++ b/claude/.claude/commands/workflow.md
@@ -98,3 +98,12 @@ These run without being asked:
 | `review-on-implement` | After significant implementation | `/code-review` |
 | `docs-suggest` | Public API added without documentation | `/go-docs`, `/py-docs`, or `/nvim-docs` |
 | `migrate-suggest` | Deprecated patterns detected in edited files | `/migrate` |
+
+---
+
+## Utilities
+
+| Tool | Command | Description |
+|---|---|---|
+| Daily task journal | `/work` | Add, list, complete, and note tasks in a date-structured work log at `~/work/` |
+| Research and publish | `/here-now` | Research any topic via live web sources and publish a self-contained report to here.now — returns a live URL |


### PR DESCRIPTION
## Summary
- Add a Utilities section to `commands/workflow.md` covering `/work` and `/here-now`

## Motivation
Both skills exist and work, but were invisible to any session reading the workflow reference. `workflow.md` is the canonical discovery surface for available commands — a skill not listed there effectively doesn't exist for most sessions.

## Changes
- `commands/workflow.md`: added a new **Utilities** section at the bottom with entries for `/work` (daily task journal at `~/work/`) and `/here-now` (research and publish to here.now)

## Test Plan
- [ ] Run `/workflow` — verify the Utilities section appears with both entries
- [ ] Confirm `/work` and `/here-now` are accessible as described