### PR TITLE
fix(ship): allow /ship -m and /ship -p to bypass protect-main hook

### DIFF
--- a/claude/.claude/hooks/protect-main.sh
+++ b/claude/.claude/hooks/protect-main.sh
@@ -10,11 +10,13 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 # Check for direct commits to main/master
 if [[ "$COMMAND" == *"git commit"* ]]; then
+  # ALLOW_MAIN_COMMIT=1 is set by /ship -m and /ship -p for authorized direct-main commits
+  [[ -n "${ALLOW_MAIN_COMMIT:-}" ]] && exit 0
   BRANCH=$(cd "${CLAUDE_PROJECT_DIR:-.}" && git branch --show-current 2>/dev/null)
   if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
     echo "[hook: protect-main] ERROR: Direct commit to '$BRANCH' is not allowed."
     echo ""
-    echo "  Create a feature branch first, or use /ship which handles branching automatically."
+    echo "  Use /ship -m to commit directly to main, or create a feature branch:"
     echo "    git checkout -b feature/<name>"
     exit 1
   fi

--- a/claude/.claude/skills/ship/SKILL.md
+++ b/claude/.claude/skills/ship/SKILL.md
@@ -283,7 +283,7 @@ Stage relevant files and write a Conventional Commit message (same rules as Step
 
 ```bash
 git add <files>
-git commit -m "..."
+ALLOW_MAIN_COMMIT=1 git commit -m "..."
 ```
 
 ### M4. Push to Main


### PR DESCRIPTION
## Summary
- Add `ALLOW_MAIN_COMMIT=1` env var bypass to `protect-main.sh` so authorized direct-main commits can proceed
- Update `/ship` skill M3 step to prefix `git commit` with `ALLOW_MAIN_COMMIT=1`
- Update error message to name `/ship -m` as the authorized path

## Motivation
`protect-main.sh` fires on every `git commit` and unconditionally blocks commits when the current branch is `main`. The `/ship -m` and `/ship -p` Direct-to-Main Workflow explicitly commits on main — so every invocation of `/ship -m` or `/ship -p` was permanently broken at step M3. The hook's own error message said "use /ship" but `/ship -m` hit the same block.

## Changes
- `hooks/protect-main.sh`: check `ALLOW_MAIN_COMMIT` env var before the branch check; update error message
- `skills/ship/SKILL.md`: M3 step prefixes `git commit` with `ALLOW_MAIN_COMMIT=1`

## Test Plan
- [ ] Run `/ship -m` with a trivial change — commit should succeed
- [ ] Run `git commit` directly on main without `ALLOW_MAIN_COMMIT` — should still be blocked