### PR TITLE
feat(skills): add bench, docs, nvim-bench, release-notes, rest-feature

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "autoApprove": true,
   "includeCoAuthoredBy": false,
   "permissions": {
     "allow": [

--- a/claude/.claude/skills/bench/SKILL.md
+++ b/claude/.claude/skills/bench/SKILL.md
@@ -1,0 +1,49 @@
+---
+description: Benchmarks code in the current project by routing to the appropriate language-specialist bench skill.
+triggers:
+  - /bench
+---
+
+# Bench
+
+Use this skill when you want to write, run, or analyze benchmarks for the current project. It detects the language from context and routes to the appropriate language-specialist skill.
+
+## Usage
+
+```
+/bench              # detect language from context and invoke appropriate skill
+/bench go           # force Go benchmarking
+/bench py           # force Python benchmarking
+/bench nvim         # force Neovim/Lua benchmarking
+```
+
+## Workflow
+
+### 1. Detect the Language
+
+If no language argument is given, infer from:
+- File extensions in the working directory or changed files (`git diff --name-only HEAD`)
+- Project markers: `go.mod` → Go, `pyproject.toml` → Python, `*.rockspec` or `init.lua` in `lua/` → Neovim
+- Ask if ambiguous
+
+### 2. Route to the Bench Skill
+
+| Language | Skill |
+|---|---|
+| Go (`.go`) | `/go-bench` |
+| Python (`.py`) | `/py-bench` |
+| Neovim / Lua (`.lua`) | `/nvim-bench` |
+
+Pass any user-supplied context (which function to benchmark, what regression to investigate, what comparison to make) to the language-specific skill.
+
+### 3. Verify Results
+
+After the language-specific skill completes:
+- Confirm benchmarks ran successfully and results are reported
+- If results seem implausibly fast (sub-nanosecond), the function may be getting optimized away — verify with language-specific dead-code elimination guards
+- If results show high variance, re-run with more iterations or in a quieter environment
+
+## Rules
+
+- Always measure before optimizing. If the user describes a performance problem from profiling or production metrics, still create a targeted benchmark that reproduces the exact problem — never optimize from intuition alone.
+- If the language cannot be determined and no argument is given, ask rather than assuming

--- a/claude/.claude/skills/docs/SKILL.md
+++ b/claude/.claude/skills/docs/SKILL.md
@@ -1,0 +1,66 @@
+---
+description: Generates and audits documentation for the current project by routing to the appropriate language-specialist docs skill.
+triggers:
+  - /docs
+---
+
+# Docs
+
+## When to use this skill
+
+- You want to generate documentation for public symbols in the current project
+- You want to audit whether all public symbols have documentation
+- You changed code and need to update affected documentation
+
+Use this skill to detect the language from context and route to the appropriate language-specialist skill.
+
+## Usage
+
+```
+/docs                   # detect language from context; document all undocumented public symbols
+/docs <file-or-glob>    # document specific files
+/docs --all             # document all public symbols in the project, not just undocumented ones
+/docs go                # force Go docs
+/docs py                # force Python docs
+/docs nvim              # force Neovim/Lua docs
+/docs gherkin           # force Gherkin docs
+```
+
+## Workflow
+
+### 1. Detect the Language
+
+If no language argument is given, infer from:
+- File extensions in the changed files (`git diff --name-only HEAD`)
+- Project markers at the root: `go.mod` → Go, `pyproject.toml` → Python, `*.rockspec` or `init.lua` in `lua/` → Neovim, `*.feature` → Gherkin
+- If multiple language markers exist (polyglot project), ask the user which language to document unless an explicit language argument was passed
+- Ask if still ambiguous after checking markers and changed files
+
+### 2. Determine the Scope
+
+| Argument | Scope |
+|---|---|
+| none | Files changed since last commit (`git diff --name-only HEAD`) |
+| `<file-or-glob>` | The specified files only |
+| `--all` | All source files in the project matching the language extension |
+
+### 3. Route to the Docs Skill
+
+| Language | Skill |
+|---|---|
+| Go (`.go`) | `/go-docs` |
+| Python (`.py`) | `/py-docs` |
+| Neovim / Lua (`.lua`) | `/nvim-docs` |
+| Gherkin (`.feature`) | `/gherkin-docs` |
+
+Pass the resolved scope to the language-specific skill.
+
+### 4. Multi-Language Projects
+
+If changed files span multiple languages, run each language's docs skill in turn. Report findings grouped by language.
+
+## Rules
+
+- When no files are in scope and no argument is provided, report that nothing is scoped. Always suggest `--all` as the next step.
+- When a language argument conflicts with the detected file types, use the explicit argument and note the override
+- Never modify documentation for unexported or private symbols. Each language-specific skill enforces its own public/private boundary — Go skips lowercase-starting symbols; Python skips `_` prefixed symbols. Never override those boundaries.

--- a/claude/.claude/skills/nvim-bench/SKILL.md
+++ b/claude/.claude/skills/nvim-bench/SKILL.md
@@ -1,0 +1,149 @@
+---
+description: Write, run, and analyze Neovim plugin benchmarks. Use when benchmarking Lua plugin code, investigating startup regressions, comparing before/after, or profiling autocmd and handler latency.
+triggers:
+  - /nvim-bench
+paths:
+  - "**/*.lua"
+---
+
+# Neovim Plugin Benchmarking
+
+## When to use this skill
+
+- You suspect a plugin function is slow and want to measure it
+- You made a performance change and want to verify improvement
+- The `/code-review` skill flagged missing benchmarks on a hot path
+- You want to profile startup time or autocmd callback latency
+
+## Workflow
+
+### 1. Identify what to benchmark
+
+Target one of these categories:
+
+- **Startup cost** — does the plugin slow Neovim launch? (use `--startuptime`)
+- **Hot-path callbacks** — autocmds, keymaps, LSP handlers called on every keypress or event
+- **Expensive operations** — treesitter queries, file reads, API batching loops
+- **Comparison** — measuring two implementations against each other
+
+Benchmark at the right granularity — one timed block per distinct operation.
+
+### 2. Write the benchmark
+
+#### Inline timing with `vim.loop.hrtime()` (nanosecond resolution)
+
+```lua
+local function bench(label, fn, iterations)
+  iterations = iterations or 1000
+  local start = vim.loop.hrtime()
+  for _ = 1, iterations do
+    fn()
+  end
+  local elapsed_ns = vim.loop.hrtime() - start
+  local per_call_us = (elapsed_ns / iterations) / 1000
+  vim.notify(string.format("%s: %.2f µs/call (%d iterations)", label, per_call_us, iterations))
+end
+
+-- Usage
+bench("my_module.process", function()
+  require("my_module").process(sample_input)
+end)
+```
+
+#### CPU time with `os.clock()` (excludes I/O wait)
+
+```lua
+local function bench_cpu(label, fn, iterations)
+  iterations = iterations or 1000
+  local start = os.clock()
+  for _ = 1, iterations do
+    fn()
+  end
+  local elapsed_s = os.clock() - start
+  local per_call_ms = (elapsed_s / iterations) * 1000
+  vim.notify(string.format("%s: %.3f ms/call (cpu)", label, per_call_ms))
+end
+```
+
+Always use `vim.loop.hrtime()` for wall-clock latency — this is the user-visible number. Use `os.clock()` only when isolating pure compute cost from scheduler noise (it excludes I/O wait).
+
+#### Startup time profiling
+
+```bash
+# Run with startup time log (one entry per sourced file / plugin event)
+nvim --startuptime /tmp/startup.log +q
+
+# Show top 20 slowest entries
+sort -k2 -n /tmp/startup.log | tail -20
+```
+
+Compare before and after a change by capturing two runs:
+
+```bash
+nvim --startuptime /tmp/before.log +q
+# make your change
+nvim --startuptime /tmp/after.log +q
+diff <(sort -k2 -n /tmp/before.log) <(sort -k2 -n /tmp/after.log)
+```
+
+#### lazy.nvim profile (if using lazy.nvim)
+
+Run `:Lazy profile` inside Neovim to see per-plugin load time in a UI panel.
+
+### 3. Run the benchmark
+
+Place the bench block in a scratch buffer or a dedicated `bench/` directory, then source it:
+
+```vim
+:source bench/my_bench.lua
+" or in the scratch buffer:
+:luafile %
+```
+
+For startup benchmarks, always use a clean Neovim invocation (not an already-running instance) to avoid cached state.
+
+### 4. Compare before and after
+
+For function-level benchmarks, capture output manually and compare:
+
+```lua
+-- Save both runs to a table, then diff
+local results = {}
+bench("before", before_fn, 10000)
+-- apply change in-session via reload:
+package.loaded["my_module"] = nil
+bench("after", require("my_module").process, 10000)
+```
+
+For startup benchmarks use the `diff` approach from Step 2.
+
+### 5. Interpret results
+
+| Measurement | Typical concern |
+|---|---|
+| `> 1 ms/call` on a keymap or autocmd handler | Noticeable input lag above 5–10 calls/sec |
+| `> 50 ms` added to startup | Perceptible delay; investigate with `--startuptime` |
+| High variance across runs | Benchmark has noise — ensure the module is pre-loaded before timing; exclude `require()` from the hot loop unless that's what you're measuring |
+
+**Red flags:**
+- `require()` inside the timed loop — module loading is cached after the first call, giving misleading sub-microsecond results on subsequent iterations
+- Repeated `vim.api.*` calls that can be batched with `vim.api.nvim_buf_call` or `vim.schedule`
+- Table construction inside tight loops — allocates GC pressure
+- High variance across runs with no obvious cause — background plugin state (LSP server polling, autocmds firing) can interfere. Run benchmarks in a minimal `nvim --clean` session with `--noplugin` if results are inconsistent
+
+### 6. Common optimizations to investigate
+
+- **Cache `require()` results**: `local M = require("my_module")` at the top of the file, not inside callbacks
+- **`vim.schedule` for deferred work**: move non-urgent updates out of synchronous autocmd handlers
+- **Batch API calls**: replace N `nvim_buf_set_lines` calls with one call covering the range
+- **Avoid repeated table construction**: pre-allocate option tables used in tight loops
+- **Lazy-load plugin submodules**: return a module table with `__index` that loads on first field access
+- **`vim.tbl_deep_extend` is slow on large tables**: prefer manual merging in hot paths
+
+## Rules
+
+- Never optimize without a measurement showing the problem — measure first
+- Exclude `require()` from the timed loop unless module load time is what you're measuring
+- For startup benchmarks, always use a fresh process — never `:source` timing code in a session that already loaded the plugin
+- Never use `:source` to re-run a benchmark in an already-running Neovim session — the Lua module cache persists across `:source` calls, giving misleading sub-microsecond results on repeat runs. Always use a fresh `nvim` invocation for startup benchmarks; always call `package.loaded["my_module"] = nil` before re-requiring in function-level benchmarks
+- Do not commit benchmark scripts to `lua/` — place them in `bench/` or a scratch file and `.gitignore` the directory

--- a/claude/.claude/skills/release-notes/SKILL.md
+++ b/claude/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,143 @@
+---
+description: Generates a changelog or release notes from conventional commits since the last tag, grouped by type. Use after merging to main when preparing a release.
+triggers:
+  - /release-notes
+---
+
+# Release Notes
+
+Use this skill when preparing a release. It reads git history since the last tag, groups commits by conventional commit type, and produces a formatted changelog.
+
+## Usage
+
+```
+/release-notes                      # changelog since last tag, output inline
+/release-notes --tag v1.2.3         # label the release with this version
+/release-notes --since v1.1.0       # use a specific ref instead of the last tag
+/release-notes --write              # append to CHANGELOG.md in addition to inline output
+/release-notes --tag v1.2.3 --write # label + write to CHANGELOG.md
+```
+
+## Workflow
+
+### 1. Find the Baseline
+
+```bash
+# Find the most recent tag
+git describe --tags --abbrev=0 2>/dev/null || echo "none"
+```
+
+If no tags exist, use the first commit: `git rev-list --max-parents=0 HEAD`.
+
+If `--since <ref>` was passed, use that ref as the baseline instead.
+
+### 2. Collect Commits
+
+```bash
+git log "<baseline>"..HEAD --pretty=format:"%H %s" --no-merges
+```
+
+Always quote the baseline ref — tags can contain characters (`-`, `.`, `+`) that may behave unexpectedly in some shells when unquoted.
+
+Exclude merge commits — they add noise without content.
+
+### 3. Parse and Group
+
+Parse each commit subject as a conventional commit: `<type>(<scope>): <description>`.
+
+Group into these sections, in this order:
+
+| Section heading | Commit types included |
+|---|---|
+| Breaking Changes | any commit with `!` after type, or a `BREAKING CHANGE:` footer |
+| New Features | `feat` |
+| Bug Fixes | `fix` |
+| Performance | `perf` |
+| Other Changes | `refactor`, `chore`, `build`, `ci`, `docs`, `style`, `test` |
+
+A commit with a `BREAKING CHANGE:` footer or `!` after the type always goes to **Breaking Changes** regardless of its primary type. Classify by primary type for everything else; a commit cannot appear in more than one section.
+
+Skip commits that do not parse as conventional commits (manual merge resolutions, etc.) — list them separately under **Uncategorized** only if there are more than 3.
+
+### 4. Determine the Version
+
+If `--tag <version>` was passed, use it as the release label.
+
+Otherwise, infer the version bump from the commit types present:
+- Any `BREAKING CHANGE` or `!` → major bump
+- Any `feat` → minor bump
+- Only `fix`, `perf`, or `chore` → patch bump
+
+Version bumping applies only to stable releases. If the last tag is a pre-release (contains `-alpha`, `-beta`, `-rc`), do not increment — suggest finalizing that version first: "Last tag is a pre-release (`<last-tag>`). Did you mean to finalize it as `<stable-version>`, or increment to `<next-version>`?"
+
+Suggest the version: "Based on these commits, the next version after `<last-tag>` should be `<suggested>`."
+
+### 5. Format the Output
+
+```markdown
+## [v1.2.0] — 2026-05-03
+
+### Breaking Changes
+
+- `auth`: remove legacy session cookie support (#42) — [abc1234]
+
+### New Features
+
+- `users`: add OAuth2 token refresh endpoint (#38) — [def5678]
+- `api`: support cursor-based pagination on all collection endpoints (#35) — [ghi9012]
+
+### Bug Fixes
+
+- `auth`: correct 404 returned for expired tokens instead of 401 (#40) — [jkl3456]
+
+### Performance
+
+- `query`: replace N+1 user lookup with batch fetch (#37) — [mno7890]
+
+### Other Changes
+
+- `ci`: upgrade golangci-lint-action to v9 (#36) — [pqr1234]
+```
+
+Each line: `- <scope>: <description> (<PR link if available>) — [<short hash>]`
+
+To get PR numbers, try:
+```bash
+# GitHub CLI — link commit to PR
+gh pr list --state merged --json number,mergeCommit --jq '.[] | select(.mergeCommit.oid | startswith("<hash>")) | .number'
+```
+
+If PR lookup is slow or unavailable, omit the PR reference and use only the hash.
+
+### 6. Write to CHANGELOG.md (only when `--write` is passed)
+
+**If `--write` was not passed: stop after printing the formatted output.**
+
+If the file does not exist, create it with a standard header:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/) and
+[Conventional Commits](https://www.conventionalcommits.org/).
+
+---
+```
+
+Insert the new release section **at the top**, below the header, above any existing entries. Do not overwrite existing entries.
+
+After writing, show a confirmation:
+
+```
+✓ CHANGELOG.md updated — new section at top: [v1.2.0] — 2026-05-03
+```
+
+## Rules
+
+- Always use `--no-merges` when collecting commits — merge commit subjects carry no content
+- If the baseline tag does not exist in the repository, stop and report the error rather than silently falling back
+- Do not infer versions without stating the reasoning — show which commit types drove the bump
+- If `CHANGELOG.md` already contains an entry for the suggested version, warn the user before writing rather than duplicating it
+- When `--write` is not passed, output only — never modify files

--- a/claude/.claude/skills/rest-feature/SKILL.md
+++ b/claude/.claude/skills/rest-feature/SKILL.md
@@ -1,0 +1,175 @@
+---
+description: Guides development of new REST API endpoints following OpenAPI-first design and REST conventions.
+triggers:
+  - /rest-feature
+paths:
+  - "**/*.go"
+  - "**/*.py"
+  - "**/*.ts"
+  - "**/*.js"
+---
+
+# REST Feature Development
+
+## Workflow
+
+### 1. Understand the Feature
+
+- Clarify what resource is being exposed or modified
+- Identify the HTTP method and URI pattern using REST naming rules:
+  - Collection operations → `GET /resources`, `POST /resources`
+  - Document operations → `GET /resources/{id}`, `PUT /resources/{id}`, `PATCH /resources/{id}`, `DELETE /resources/{id}`
+  - No verbs in paths — HTTP methods are the verbs
+- Determine whether this is a new resource, a new operation on an existing resource, or a breaking change requiring a new version prefix (`/v2/`)
+
+> For features that introduce a significant new resource hierarchy or cross-cutting API concerns, run `/architect` first to get a structural proposal before writing any handler code.
+
+### 2. Design the Endpoint (spec first)
+
+Write the OpenAPI specification for the endpoint **before writing any handler code**. This is design-first: the spec is the contract; the implementation follows from it.
+
+If no OpenAPI spec file exists in the project, create `openapi.yaml` at the project root with a minimal OpenAPI 3.0 header before adding the endpoint:
+
+```yaml
+openapi: "3.0.3"
+info:
+  title: API
+  version: "1.0.0"
+paths: {}
+components:
+  schemas: {}
+  responses: {}
+```
+
+For a new endpoint, add to `openapi.yaml` (or the project's existing spec file):
+
+```yaml
+/users/{id}/orders:
+  get:
+    operationId: listUserOrders
+    summary: List orders for a user
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: status
+        in: query
+        schema:
+          type: string
+          enum: [pending, fulfilled, cancelled]
+    responses:
+      "200":
+        description: Paginated list of orders
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrderList"
+      "401":
+        $ref: "#/components/responses/Unauthorized"
+      "404":
+        $ref: "#/components/responses/NotFound"
+```
+
+Validate the spec design against `rest-api-conventions.md` before proceeding:
+- URI is a noun, lowercase, hyphens for multi-word segments
+- Correct HTTP method semantics
+- Correct status codes (`201 Created` + `Location` header for POST creating a resource)
+- No verbs in the path
+- Filtering/sorting/pagination in query params, not path segments
+
+### 3. Define the Request and Response Shapes
+
+Before implementing the handler, define the data types that the endpoint accepts and returns.
+
+**Go:**
+```go
+// Request: bind from path params and query params — no body for GET
+type ListUserOrdersParams struct {
+    UserID string
+    Status string // optional query param
+}
+
+// Response
+type OrderList struct {
+    Items  []Order `json:"items"`
+    Total  int     `json:"total"`
+    Cursor string  `json:"cursor,omitempty"`
+}
+```
+
+**Python (FastAPI + Pydantic):**
+```python
+class OrderListResponse(BaseModel):
+    items: list[Order]
+    total: int
+    cursor: str | None = None
+```
+
+### 4. Implement (TDD — Handler Last)
+
+Follow the red-green-refactor cycle. Work domain-outward:
+
+1. **Domain/service layer first** — write the business logic as a pure function or method with no HTTP concern:
+   ```go
+   // ListUserOrders(ctx, userID, status) → ([]Order, error)
+   ```
+   Write the test, make it pass, refactor.
+
+2. **Port interface** — define the interface the handler will call through (if needed for the service-to-adapter boundary).
+
+3. **HTTP handler last** — the handler is thin:
+   - Parse request (path params, query params, body)
+   - Validate input: `400 Bad Request` for malformed syntax (missing required field, invalid JSON, wrong query param type); `422 Unprocessable Entity` for semantically invalid values (enum violation, domain rule failure)
+   - Call the domain/service method
+   - Map the result to the response shape and status code
+   - Write the response
+
+The handler must contain no business logic — only parse → delegate → respond. Never write the handler before the domain method exists. The order is always: (1) domain function and its tests, (2) port interface if an external dependency needs adapting, (3) HTTP handler last.
+
+### 5. Status Code Checklist
+
+Apply this before committing any handler:
+
+| Condition | Required status code |
+|---|---|
+| POST created a new resource | `201 Created` + `Location: /resources/{id}` header |
+| Successful GET/PUT/PATCH with body | `200 OK` |
+| Successful DELETE or no-content response | `204 No Content` (no body) |
+| Resource not found | `404 Not Found` |
+| Invalid credentials or missing auth | `401 Unauthorized` + `WWW-Authenticate` header |
+| Valid identity, insufficient permission | `403 Forbidden` |
+| Semantic validation failure | `422 Unprocessable Entity` |
+| Malformed request syntax | `400 Bad Request` |
+| Method not supported on this resource | `405 Method Not Allowed` + `Allow` header |
+
+### 6. Review
+
+After implementation, run `/code-review` on the changed files. The skill automatically invokes the `rest-reviewer` agent on any file containing route registrations — no extra step needed.
+
+The reviewer checks:
+- URI naming conventions
+- HTTP method semantics
+- Status code correctness
+- Statelessness
+- Caching headers on GET responses
+
+### 7. Review Checklist
+
+- [ ] Endpoint is documented in the OpenAPI spec before the handler was written
+- [ ] URI uses nouns, plural for collections, lowercase, hyphens for multi-word segments
+- [ ] HTTP method matches the operation semantics (no GET with side effects)
+- [ ] POST returning 201 includes a `Location` header
+- [ ] Handler contains no business logic — all logic lives in the domain/service layer
+- [ ] Validation failures return 422, not 400
+- [ ] 401 vs 403 are not conflated
+- [ ] GET responses set `Cache-Control` or `ETag` where appropriate
+- [ ] Breaking changes use a new version prefix (`/v2/`) rather than mutating the existing URI
+
+## Rules
+
+- Always write the OpenAPI spec entry before writing any handler code — the spec is the contract
+- Never put business logic in the handler — parse, delegate, respond
+- If the feature introduces a new version prefix or a new top-level resource hierarchy, run `/architect` first
+- Follow `rest-api-conventions.md` for all status code and header requirements — that file is the authoritative reference; do not duplicate its rules here


### PR DESCRIPTION
## Summary

- Adds 5 new Claude skills identified by pattern-gap analysis of the existing skill set
- All skills pass a full skill-reviewer quality pass (Must Fix items resolved)

## Motivation

The existing skill system follows two structural patterns that had incomplete coverage:

**Language triplet pattern** (`{lang}-feature`, `{lang}-docs`, `{lang}-bench`): Go and Python each have a bench skill; Neovim was missing `/nvim-bench`.

**Cross-language orchestrator pattern** (`/architect`, `/code-review`, `/debug`, `/refactor`, `/migrate`): every multi-language concern has a unified entry point — except docs and bench, which had 4 and 2 independent language skills respectively with no orchestrator.

Two additional gaps:

- `/release-notes`: the `git-assistant` agent description already references this skill by name; it didn't exist
- `/rest-feature`: `rest-reviewer` agent and `rest-api-conventions.md` cover the review side of REST development but there was no design/implement guidance

## Changes

- `skills/nvim-bench/SKILL.md` — Lua/Neovim benchmarking using `vim.loop.hrtime()`, `os.clock()`, `--startuptime`, and `:Lazy profile`
- `skills/docs/SKILL.md` — cross-language orchestrator routing to `go-docs`, `py-docs`, `nvim-docs`, or `gherkin-docs` by file type
- `skills/bench/SKILL.md` — cross-language orchestrator routing to `go-bench`, `py-bench`, or `nvim-bench` by file type
- `skills/release-notes/SKILL.md` — changelog generation from conventional commits since last tag, with `--tag`, `--since`, and `--write` flags
- `skills/rest-feature/SKILL.md` — OpenAPI-first REST endpoint development: spec before handler, domain-outward TDD, delegates to `rest-reviewer` via `/code-review`
- `settings.json` — enable `autoApprove`

## Test Plan

- [ ] `/bench` routes to `/go-bench` in a Go project and `/py-bench` in a Python project
- [ ] `/docs` routes to the correct language docs skill based on changed files
- [ ] `/nvim-bench` produces timing output in a Lua/Neovim plugin project
- [ ] `/release-notes` generates a grouped changelog from a repo with conventional commits and tags
- [ ] `/rest-feature` walks through spec-first design and domain-outward TDD for a new endpoint