### PR TITLE
refactor(skills): remove bogus triggers field from frontmatter

### DIFF
--- a/claude/.claude/skills/architect/SKILL.md
+++ b/claude/.claude/skills/architect/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Designs application architecture by delegating to the appropriate language-specialist architect agent.
-triggers:
-  - /architect
 ---
 
 # Architect

--- a/claude/.claude/skills/audit/SKILL.md
+++ b/claude/.claude/skills/audit/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Audits the Claude workflow system — reads every component and reports what's suboptimal with specific fixes, grouped by category and ordered by impact.
-triggers:
-  - /audit
 ---
 
 # Workflow Audit

--- a/claude/.claude/skills/bench/SKILL.md
+++ b/claude/.claude/skills/bench/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Benchmarks code in the current project by routing to the appropriate language-specialist bench skill.
-triggers:
-  - /bench
 ---
 
 # Bench

--- a/claude/.claude/skills/code-review/SKILL.md
+++ b/claude/.claude/skills/code-review/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Runs a structured code review of changed files by delegating to language-specialist reviewer agents.
-triggers:
-  - /code-review
 ---
 
 # Code Review

--- a/claude/.claude/skills/debug/SKILL.md
+++ b/claude/.claude/skills/debug/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Systematically triages and diagnoses bugs across Go, Python, Neovim, and Gherkin.
-triggers:
-  - /debug
 paths:
   - "**/*.go"
   - "**/*.py"

--- a/claude/.claude/skills/dir/SKILL.md
+++ b/claude/.claude/skills/dir/SKILL.md
@@ -1,8 +1,5 @@
 ---
 description: Reports the current working directory with project context — language, type, and git status.
-triggers:
-  - /dir
-  - /pwd
 ---
 
 # Dir: Working Directory Report

--- a/claude/.claude/skills/doc-review/SKILL.md
+++ b/claude/.claude/skills/doc-review/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Reviews documentation files against Write the Docs principles — structure, content quality, accuracy, accessibility, and UX copy — and reports findings by severity.
-triggers:
-  - /doc-review
 ---
 
 # Documentation Review

--- a/claude/.claude/skills/docs/SKILL.md
+++ b/claude/.claude/skills/docs/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Generates and audits documentation for the current project by routing to the appropriate language-specialist docs skill.
-triggers:
-  - /docs
 ---
 
 # Docs

--- a/claude/.claude/skills/gherkin-docs/SKILL.md
+++ b/claude/.claude/skills/gherkin-docs/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Generates living documentation from Gherkin feature files as readable Markdown summaries.
-triggers:
-  - /gherkin-docs
 paths:
   - "**/*.feature"
 ---

--- a/claude/.claude/skills/gherkin-feature/SKILL.md
+++ b/claude/.claude/skills/gherkin-feature/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Guides writing new Gherkin feature files and step definitions following BDD best practices.
-triggers:
-  - /gherkin-feature
 paths:
   - "**/*.feature"
 ---

--- a/claude/.claude/skills/go-bench/SKILL.md
+++ b/claude/.claude/skills/go-bench/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Write, run, and analyze Go benchmarks. Use when benchmarking Go code, investigating performance regressions, comparing before/after, or analyzing allocations and throughput.
-triggers:
-  - /go-bench
 paths:
   - "**/*.go"
 ---

--- a/claude/.claude/skills/go-docs/SKILL.md
+++ b/claude/.claude/skills/go-docs/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Generates and audits Go package documentation following godoc conventions.
-triggers:
-  - /go-docs
 paths:
   - "**/*.go"
 ---

--- a/claude/.claude/skills/go-feature/SKILL.md
+++ b/claude/.claude/skills/go-feature/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Guides development of new Go features following clean architecture and idiomatic Go patterns.
-triggers:
-  - /go-feature
 paths:
   - "**/*.go"
 ---

--- a/claude/.claude/skills/here-now/SKILL.md
+++ b/claude/.claude/skills/here-now/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Researches a topic using live web sources, synthesizes a structured report, and publishes it to here.now — returns a live URL.
-triggers:
-  - /here-now
 ---
 
 # Here Now: Research and Publish to here.now

--- a/claude/.claude/skills/main/SKILL.md
+++ b/claude/.claude/skills/main/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Checks out the main branch and pulls the latest changes from remote.
-triggers:
-  - /main
 ---
 
 # Main: Checkout and Pull Latest

--- a/claude/.claude/skills/migrate/SKILL.md
+++ b/claude/.claude/skills/migrate/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Identifies and replaces deprecated or outdated patterns across Go, Python, Neovim, and Gherkin.
-triggers:
-  - /migrate
 paths:
   - "**/*.go"
   - "**/*.py"

--- a/claude/.claude/skills/nvim-bench/SKILL.md
+++ b/claude/.claude/skills/nvim-bench/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Write, run, and analyze Neovim plugin benchmarks. Use when benchmarking Lua plugin code, investigating startup regressions, comparing before/after, or profiling autocmd and handler latency.
-triggers:
-  - /nvim-bench
 paths:
   - "**/*.lua"
 ---

--- a/claude/.claude/skills/nvim-docs/SKILL.md
+++ b/claude/.claude/skills/nvim-docs/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Generates Neovim plugin documentation in vimdoc format.
-triggers:
-  - /nvim-docs
 paths:
   - "**/*.lua"
 ---

--- a/claude/.claude/skills/nvim-feature/SKILL.md
+++ b/claude/.claude/skills/nvim-feature/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Guides development of new Neovim plugin features using idiomatic Lua and the Neovim API.
-triggers:
-  - /nvim-feature
 paths:
   - "**/*.lua"
 ---

--- a/claude/.claude/skills/patterns/SKILL.md
+++ b/claude/.claude/skills/patterns/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Analyzes code or a problem description and recommends applicable GoF design patterns with implementation sketches grounded in the code.
-triggers:
-  - /patterns
 ---
 
 # Pattern Advisor

--- a/claude/.claude/skills/py-bench/SKILL.md
+++ b/claude/.claude/skills/py-bench/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Write, run, and analyze Python benchmarks. Use when benchmarking Python code, investigating performance regressions, comparing before/after, or profiling allocations and throughput.
-triggers:
-  - /py-bench
 paths:
   - "**/*.py"
 ---

--- a/claude/.claude/skills/py-docs/SKILL.md
+++ b/claude/.claude/skills/py-docs/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Generates and audits Python documentation following Google-style docstring conventions.
-triggers:
-  - /py-docs
 paths:
   - "**/*.py"
 ---

--- a/claude/.claude/skills/py-feature/SKILL.md
+++ b/claude/.claude/skills/py-feature/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Guides development of new Python features following hexagonal architecture and clean code principles.
-triggers:
-  - /py-feature
 paths:
   - "**/*.py"
 ---

--- a/claude/.claude/skills/refactor/SKILL.md
+++ b/claude/.claude/skills/refactor/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Guides structural refactoring of Go, Python, or Neovim code — improving design, layering, and clarity without changing behavior.
-triggers:
-  - /refactor
 paths:
   - "**/*.go"
   - "**/*.py"

--- a/claude/.claude/skills/release-notes/SKILL.md
+++ b/claude/.claude/skills/release-notes/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Generates a changelog or release notes from conventional commits since the last tag, grouped by type. Use after merging to main when preparing a release.
-triggers:
-  - /release-notes
 ---
 
 # Release Notes

--- a/claude/.claude/skills/rest-feature/SKILL.md
+++ b/claude/.claude/skills/rest-feature/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Guides development of new REST API endpoints following OpenAPI-first design and REST conventions.
-triggers:
-  - /rest-feature
 paths:
   - "**/*.go"
   - "**/*.py"

--- a/claude/.claude/skills/rest-review/SKILL.md
+++ b/claude/.claude/skills/rest-review/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Reviews HTTP handler and route code for REST API convention compliance — resource naming, HTTP methods, status codes, statelessness, and caching.
-triggers:
-  - /rest-review
 ---
 
 # REST Review

--- a/claude/.claude/skills/ship/SKILL.md
+++ b/claude/.claude/skills/ship/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Creates a feature or hotfix branch, commits staged changes, pushes to remote, and opens a detailed PR against main. Supports -m to commit directly to main, or -p to commit a patch fix directly to main.
-triggers:
-  - /ship
 ---
 
 # Ship: Branch → Commit → Push → PR

--- a/claude/.claude/skills/skill-audit/SKILL.md
+++ b/claude/.claude/skills/skill-audit/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Audits all existing Claude skill files for structural quality, language durability, and consistency with rules and agents. Produces a prioritized findings report.
-triggers:
-  - /skill-audit
 ---
 
 # Skill Audit

--- a/claude/.claude/skills/sync/SKILL.md
+++ b/claude/.claude/skills/sync/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Rebases the current feature branch onto the latest main, handling stash and conflict guidance.
-triggers:
-  - /sync
 ---
 
 # Sync: Rebase Feature Branch onto Main

--- a/claude/.claude/skills/test-driven-development/SKILL.md
+++ b/claude/.claude/skills/test-driven-development/SKILL.md
@@ -1,7 +1,5 @@
 ---
 description: Deep TDD reference — red-green-refactor cycle, language-specific tooling, and anti-patterns. Auto-triggered guidance lives in rules/tdd.md; invoke /tdd for the full reference.
-triggers:
-  - /tdd
 ---
 
 # Test-Driven Development


### PR DESCRIPTION
## Summary
- Removes the `triggers:` YAML field from 31 SKILL.md files. It is not a real Claude Code frontmatter field — the directory name automatically becomes the slash command.
- `skill-author/SKILL.md` is intentionally **excluded** from this PR. The tutorial it contains still demonstrates the bogus field; that will be addressed in a follow-up so the cleanup of the surface (this PR) lands separately from the tutorial-content rewrite.

## Motivation
Audit of the official Claude Code skill documentation (https://code.claude.com/docs/en/skills#frontmatter-reference) confirms `triggers:` is not in the supported field set. Every existing skill in this repo carried it and it was being silently ignored. Removing it:

1. Eliminates dead noise from every skill's frontmatter, reducing Level 1 metadata tokens that load every session.
2. Stops new skills from inheriting the bogus field via copy-paste.
3. Aligns the codebase with the conventions documented in the new `skills/CLAUDE.md` (PR #30).

The `dir` skill previously listed both `/dir` and `/pwd` as triggers — both were already non-functional (the field is ignored). If `/pwd` is wanted as a real alias, it needs its own `skills/pwd/` directory; flagging here rather than silently dropping.

## Test Plan
- [ ] Confirm `/<skill-name>` still invokes every affected skill (smoke-test a representative subset: `/ship`, `/audit`, `/dir`, `/sync`)
- [ ] Confirm the skills listing in a new session no longer shows the field
- [ ] Verify no SKILL.md outside this PR's diff was touched